### PR TITLE
ci: Run AWS integration tests monthly + manual only

### DIFF
--- a/.github/workflows/aws-integration-tests.yml
+++ b/.github/workflows/aws-integration-tests.yml
@@ -16,19 +16,12 @@ on:
           - ec2
           - cleanup
           - quick
-  # Run on push to main (but only for relevant changes)
-  push:
-    branches: [main]
-    paths:
-      - 'R/**'
-      - 'inst/templates/**'
-      - 'tests/testthat/test-detached-sessions.R'
-      - 'tests/testthat/test-integration-examples.R'
-      - 'tests/testthat/test-ec2-*.R'
-      - 'tests/testthat/test-cleanup.R'
-  # Run weekly to catch infrastructure drift
+  # No automatic run on push: these tests provision real AWS resources
+  # (Fargate workers, Docker image builds, EC2). Run them on demand via the
+  # workflow_dispatch above, or on the monthly drift-detection schedule below.
+  # Run monthly to catch infrastructure drift
   schedule:
-    - cron: '0 8 * * 1'  # Monday 8am UTC
+    - cron: '0 8 1 * *'  # 1st of the month, 08:00 UTC
 
 jobs:
   aws-integration-tests:

--- a/.github/workflows/aws-integration-tests.yml
+++ b/.github/workflows/aws-integration-tests.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Run detached session tests
         if: github.event.inputs.test_suite == 'detached-sessions' || github.event.inputs.test_suite == 'all'
+        env:
+          RUN_INTEGRATION_TESTS: "TRUE"  # opt-in gate for tests that launch real Fargate workers
         run: |
           Rscript -e "
             devtools::load_all()


### PR DESCRIPTION
Addresses the cadence half of #26.

These tests provision **real AWS resources** (Fargate workers, multi-platform Docker image builds, EC2 via ASG), so they shouldn't run automatically on every push.

**Change to `.github/workflows/aws-integration-tests.yml` triggers:**
- ❌ Removed the `push: branches:[main]` trigger
- 🔁 Schedule weekly (`0 8 * * 1`) → **monthly** (`0 8 1 * *`, 1st at 08:00 UTC), matching `build-base-images.yml`
- ✅ Kept `workflow_dispatch` (with its `test_suite` choice: all / detached-sessions / integration-examples / ec2 / cleanup / quick) for on-demand runs

**Not addressed here** (still open in #26 for discussion/decision):
- The broken OIDC credentials (`AWS_ROLE_ARN` secret / IAM trust policy) — the actual cause of the red runs. Until that's fixed, even the monthly run will fail; consider this PR the cadence decision, with the creds fix tracked separately in #26.
- Optional: lower `timeout-minutes`, switch scheduled run to the `quick` suite, bump Node 20 actions.

Refs #26