### PR TITLE
ci: Provision staRburst in CI + bump actions to current versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/aws-integration-tests.yml
+++ b/.github/workflows/aws-integration-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
 
       - name: Setup R dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ hashFiles('DESCRIPTION') }}
@@ -67,7 +67,7 @@ jobs:
           R CMD INSTALL .
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
@@ -77,6 +77,16 @@ jobs:
         run: |
           aws sts get-caller-identity
           aws s3 ls || echo "No S3 buckets or access denied"
+
+      - name: Configure staRburst (provision AWS resources)
+        # CI runners are ephemeral and have no persisted staRburst config, so
+        # run setup to create the S3 bucket / ECR repo / ECS cluster and write
+        # the local config that the test suites read via get_starburst_config().
+        run: |
+          Rscript -e "
+            devtools::load_all()
+            starburst_setup(region = 'us-east-1', force = TRUE)
+          "
 
       - name: Run quick smoke tests
         if: github.event.inputs.test_suite == 'quick' || github.event.inputs.test_suite == 'all'
@@ -209,7 +219,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release with manifest
         env:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
Follow-up to the OIDC setup for #26. The GitHub→AWS OIDC role (`starburst-github-actions`) now exists and **authenticates successfully** — a manual `quick` run got past `Configure AWS credentials` and `Verify AWS access` (both ✓). Two remaining fixes:

### 1. Provision staRburst in CI
That `quick` run then failed at the smoke test with `staRburst not configured. Run starburst_setup() first.` — `get_starburst_config()` reads a local RDS config written by `starburst_setup()`, which an ephemeral runner never has. Added a **Configure staRburst** step (`starburst_setup(region='us-east-1', force=TRUE)`) right after the AWS credentials step, so the S3 bucket / ECR repo / ECS cluster and local config exist before any suite runs. The new OIDC role has exactly the permissions for this.

### 2. Actions up to date (June 2026)
Bump off the deprecated Node 20 runtime (forced to Node 24 from 2026-06-16):
- `actions/checkout` v3/v4 → **v6** (all workflows)
- `actions/cache` v3 → **v5**
- `actions/upload-artifact` v4 → **v7**
- `aws-actions/configure-aws-credentials` v4 → **v6** (aws-integration-tests + build-base-images)

### Verification plan
The `aws-integration-tests` workflow only runs on dispatch/schedule (not on PRs), and its IAM trust policy is scoped to `refs/heads/main` — so it can only be verified **after merge** via a manual `quick` dispatch from main. The R-CMD-check and pkgdown checks on this PR validate that the `checkout@v6` bumps don't break those workflows.

Refs #26