### PR TITLE
Docs re-review follow-ups: fix launch_type bug + finish consistency sweep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: starburst
 Type: Package
 Title: Seamless AWS Cloud Bursting for Parallel R Workloads
-Version: 0.3.8
+Version: 0.3.9
 Authors@R: c(
     person("Scott", "Friedman", email = "help@starburst.ing", role = c("aut", "cre"))
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# starburst 0.3.9 (development)
+
+## Bug fixes
+
+* **`starburst_map()` and `starburst_cluster()` now accept `launch_type`,
+  `instance_type`, and `use_spot`** and forward them to the backend. Previously
+  these functions had no backend arguments, so a call like
+  `starburst_map(x, f, launch_type = "FARGATE")` silently passed `launch_type`
+  to the mapped function `.f` (typically an "unused argument" error) instead of
+  switching the backend — contradicting the 0.3.7 migration note. Backend
+  selection now works uniformly across `plan(starburst)`, `starburst_map()`,
+  `starburst_cluster()`, and `starburst_session()`.
+
+## Documentation
+
+* Consistency sweep addressing an external documentation review: EC2 is now
+  consistently presented as the default/recommended backend with Fargate as the
+  optional alternative; the README and example console output match the current
+  engine (ASCII status markers, one task per input element — no chunking step);
+  the Getting Started tutorial leads with `starburst_map()`; a grouped reference
+  index and an architecture diagram were added; and `starburst_config()` keys are
+  now catalogued.
+
 # starburst 0.3.8 (2026-03-06)
 
 ## Reliability & CRAN readiness

--- a/R/session-api.R
+++ b/R/session-api.R
@@ -22,15 +22,42 @@ NULL
 #' @param use_spot Use spot instances for EC2 (default: TRUE)
 #' @param warm_pool_timeout EC2 warm pool timeout in seconds (default: 3600)
 #'
-#' @return A StarburstSession object with methods:
-#'   \itemize{
-#'     \item \code{submit(expr, ...)} - Submit a task to the session
-#'     \item \code{status()} - Get progress summary
-#'     \item \code{collect(wait = FALSE)} - Collect completed results
-#'     \item \code{extend(seconds = 3600)} - Extend timeout
-#'     \item \code{cleanup()} - Terminate and cleanup
+#' @return A \code{StarburstSession} object (also carrying \code{$session_id}, the
+#'   handle you pass to \code{\link{starburst_session_attach}}) with methods:
+#'   \describe{
+#'     \item{\code{submit(expr, globals = NULL, packages = NULL)}}{Submit one task
+#'       (a quoted expression). Returns the task id. Call repeatedly to fan out work.}
+#'     \item{\code{status()}}{Return a progress summary (counts of pending / running
+#'       / completed / failed tasks). Safe to call from a fresh R session after
+#'       reattaching.}
+#'     \item{\code{collect(wait = FALSE)}}{Retrieve results. With \code{wait = FALSE}
+#'       returns whatever has completed so far; with \code{wait = TRUE} blocks until
+#'       all submitted tasks finish. Results come back in submission order.}
+#'     \item{\code{extend(seconds = 3600)}}{Extend the active/absolute timeout of a
+#'       still-running session.}
+#'     \item{\code{cleanup()}}{Stop all tasks/workers for the session and delete its
+#'       S3 objects. Call when done; otherwise the session self-terminates at
+#'       \code{absolute_timeout}.}
 #'   }
 #'
+#' @section Lifecycle:
+#' \code{starburst_session()} launches workers immediately and returns a handle.
+#' Submit tasks, then either poll \code{status()}/\code{collect()} in the same
+#' session, or record \code{session$session_id}, close R, and later
+#' \code{\link{starburst_session_attach}(session_id)} to reconnect and collect.
+#' A session ends when you call \code{cleanup()}, when \code{session_timeout}
+#' elapses with no activity, or at \code{absolute_timeout} — whichever comes first.
+#'
+#' @section Failure behavior:
+#' A failed task is recorded (surfaced via \code{status()}) and does not abort the
+#' others; its error is raised when you \code{collect()} that result. If the client
+#' dies, workers keep running against S3 until a timeout, which is what makes
+#' reattaching possible. \code{cleanup()} is the only thing that frees resources
+#' early — sessions do not auto-clean on garbage collection.
+#'
+#' @seealso \code{\link{starburst_session_attach}},
+#'   \code{\link{starburst_list_sessions}}; \code{\link{starburst_map}} for
+#'   ephemeral (non-detached) fan-out.
 #' @export
 #'
 #' @examples

--- a/R/setup.R
+++ b/R/setup.R
@@ -252,21 +252,48 @@ config_path <- function() {
 
 #' Configure staRburst options
 #'
-#' @param max_cost_per_job Maximum cost per job in dollars
-#' @param cost_alert_threshold Cost threshold for alerts
-#' @param auto_cleanup_s3 Automatically clean up S3 files after completion
-#' @param ... Additional configuration options
+#' Reads and updates the persisted staRburst configuration. Call with no arguments
+#' to leave settings unchanged (it still returns the current config invisibly); pass
+#' one or more of the arguments below to update them.
+#'
+#' @param max_cost_per_job Maximum estimated cost (USD) for a single job. Jobs whose
+#'   estimate exceeds this error before launching. \code{NULL} leaves it unchanged.
+#' @param cost_alert_threshold Estimated cost (USD) at which a warning is emitted.
+#'   \code{NULL} leaves it unchanged.
+#' @param auto_cleanup_s3 Logical; automatically delete a job's S3 task/result
+#'   objects after completion. \code{NULL} leaves it unchanged.
+#' @param ... Additional user-settable keys merged into the config. Recognized keys:
+#'   \describe{
+#'     \item{\code{use_public_base}}{Logical; pull the public base image instead of
+#'       building a private one (see \code{\link{starburst_setup}}).}
+#'     \item{\code{ecr_image_ttl_days}}{Integer; lifecycle age at which cached ECR
+#'       images are expired.}
+#'   }
+#'
+#' @details
+#' Other keys in the stored config are **infrastructure-managed** — written by
+#' \code{\link{starburst_setup}}/\code{\link{starburst_setup_ec2}} and not intended
+#' to be set by hand: \code{region}, \code{bucket}, \code{cluster},
+#' \code{ecr_repository}, \code{aws_account_id}, \code{execution_role_arn},
+#' \code{task_role_arn}, \code{subnets}, and \code{security_groups}. Use
+#' \code{\link{starburst_status}} to inspect the effective configuration read-only.
 #'
 #' @return Invisibly returns the updated configuration list.
+#' @seealso \code{\link{starburst_status}} to view config without changing it;
+#'   \code{\link{starburst_setup}} for initial provisioning.
 #' @export
 #'
 #' @examples
 #' \donttest{
 #' if (starburst_is_configured()) {
+#'   # Update cost guardrails
 #'   starburst_config(
 #'     max_cost_per_job = 10,
 #'     cost_alert_threshold = 5
 #'   )
+#'
+#'   # Read the current config without changing anything
+#'   cfg <- starburst_config()
 #' }
 #' }
 starburst_config <- function(max_cost_per_job = NULL,

--- a/R/starburst-map.R
+++ b/R/starburst-map.R
@@ -11,6 +11,10 @@
 #' @param platform CPU architecture (X86_64 or ARM64)
 #' @param region AWS region
 #' @param timeout Maximum runtime in seconds per task
+#' @param launch_type Compute backend: "EC2" (default) or "FARGATE"
+#' @param instance_type EC2 instance type when \code{launch_type = "EC2"}
+#'   (default: "c7g.xlarge")
+#' @param use_spot Use EC2 Spot instances for cost savings (default: TRUE)
 #' @param .progress Show progress bar (default: TRUE)
 #' @param ... Additional arguments passed to .f
 #'
@@ -31,11 +35,16 @@
 #'     cpu = 4,
 #'     memory = "8GB"
 #'   )
+#'
+#'   # Use the Fargate backend instead of the EC2 default
+#'   results <- starburst_map(1:100, function(x) x^2,
+#'                            workers = 10, launch_type = "FARGATE")
 #' }
 #' }
 starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
                           platform = "X86_64", region = NULL, timeout = 3600,
-                          .progress = TRUE, ...) {
+                          launch_type = "EC2", instance_type = "c7g.xlarge",
+                          use_spot = TRUE, .progress = TRUE, ...) {
 
   # Validate inputs
   validate_workers(workers)
@@ -68,7 +77,10 @@ starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
     memory = memory,
     platform = platform,
     region = region,
-    timeout = timeout
+    timeout = timeout,
+    launch_type = launch_type,
+    instance_type = instance_type,
+    use_spot = use_spot
   )
 
   future::plan(strategy)
@@ -176,6 +188,10 @@ starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
 #' @param platform CPU architecture (X86_64 or ARM64)
 #' @param region AWS region
 #' @param timeout Maximum runtime in seconds
+#' @param launch_type Compute backend: "EC2" (default) or "FARGATE"
+#' @param instance_type EC2 instance type when \code{launch_type = "EC2"}
+#'   (default: "c7g.xlarge")
+#' @param use_spot Use EC2 Spot instances for cost savings (default: TRUE)
 #'
 #' @return A starburst_cluster object
 #' @export
@@ -185,10 +201,15 @@ starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
 #' if (starburst_is_configured()) {
 #'   cluster <- starburst_cluster(workers = 20)
 #'   results <- cluster$map(data, function(x) x * 2)
+#'
+#'   # Fargate backend instead of the EC2 default
+#'   fg <- starburst_cluster(workers = 20, launch_type = "FARGATE")
 #' }
 #' }
 starburst_cluster <- function(workers = 10, cpu = 4, memory = "8GB",
-                              platform = "X86_64", region = NULL, timeout = 3600) {
+                              platform = "X86_64", region = NULL, timeout = 3600,
+                              launch_type = "EC2", instance_type = "c7g.xlarge",
+                              use_spot = TRUE) {
 
   # Get configuration
   config <- get_starburst_config()
@@ -202,7 +223,10 @@ starburst_cluster <- function(workers = 10, cpu = 4, memory = "8GB",
     memory = memory,
     platform = platform,
     region = region,
-    timeout = timeout
+    timeout = timeout,
+    launch_type = launch_type,
+    instance_type = instance_type,
+    use_spot = use_spot
   )
 
   future::plan(strategy)

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,7 +53,8 @@ remotes::install_github("scttfrdmn/starburst")
 ```{r}
 library(starburst)
 
-# One-time setup (2 minutes)
+# One-time setup (~2 min to provision; first run also builds the worker image,
+# +5-10 min once)
 starburst_setup()
 
 # Run parallel computation on AWS
@@ -62,16 +63,12 @@ results <- starburst_map(
   function(x) expensive_computation(x),
   workers = 50
 )
-#> 🚀 Starting starburst cluster with 50 workers
-#> 💰 Estimated cost: ~$2.80/hour
-#> 📊 Processing 1000 items with 50 workers
-#> 📦 Created 50 chunks (avg 20 items per chunk)
-#> 🚀 Submitting tasks...
-#> ✓ Submitted 50 tasks
-#> ⏳ Progress: 50/50 tasks (3.2 minutes elapsed)
-#>
-#> ✓ Completed in 3.2 minutes
-#> 💰 Estimated cost: $0.15
+#> [Starting] Starting starburst cluster with 50 workers
+#> [Status] Processing 1000 items with 50 workers
+#> [Starting] Submitting 1000 tasks...
+#> [Wait] Progress: 1000/1000 (192.0s)
+#> [OK] Completed in 192.0 seconds
+#> [Cost] Estimated cost: $0.15
 ```
 
 ## Example: Monte Carlo Simulation
@@ -97,13 +94,12 @@ results <- starburst_map(
   simulate_portfolio,
   workers = 100
 )
-#> 🚀 Starting starburst cluster with 100 workers
-#> 💰 Estimated cost: ~$5.60/hour
-#> 📊 Processing 10000 items with 100 workers
-#> ⏳ Progress: 100/100 tasks (3.1 minutes elapsed)
-#>
-#> ✓ Completed in 3.1 minutes
-#> 💰 Estimated cost: $0.29
+#> [Starting] Starting starburst cluster with 100 workers
+#> [Status] Processing 10000 items with 100 workers
+#> [Starting] Submitting 10000 tasks...
+#> [Wait] Progress: 10000/10000 (186.0s)
+#> [OK] Completed in 186.0 seconds
+#> [Cost] Estimated cost: $0.29
 
 # Extract results
 final_values <- sapply(results, function(x) x$final_value)
@@ -184,13 +180,17 @@ session$cleanup(force = TRUE)
 ## How It Works
 
 1. **Environment Snapshot**: Captures your R packages using renv
-2. **Container Build**: Creates Docker image with your environment, cached in ECR
-3. **Task Distribution**: Splits data into chunks across workers
-4. **Task Submission**: Launches Fargate tasks (or sequential batches if quota-limited)
-5. **Data Transfer**: Serializes task data to S3 using fast qs format
-6. **Execution**: Workers pull data, execute function on chunk items, push results
-7. **Result Collection**: Downloads and combines results in correct order
-8. **Cleanup**: Automatically shuts down workers
+2. **Container Build**: Creates a Docker image with your environment, cached in ECR
+3. **Task Creation**: Creates one task per element of your input (`.x`) — there is
+   no automatic chunking; batch small items yourself if per-task overhead matters
+4. **Worker Launch**: Starts EC2 workers by default (Spot-enabled), or Fargate tasks
+   if you pass `launch_type = "FARGATE"`; falls back to waves if quota-limited
+5. **Data Transfer**: Serializes each task's function, inputs, and globals to S3
+   using the fast `qs2` format
+6. **Execution**: Each worker pulls a task from S3, runs your function, pushes the
+   result back to S3
+7. **Result Collection**: Downloads and combines results in the original order
+8. **Cleanup**: Automatically shuts workers down (warm-pool timeout configurable)
 
 ## Cost Management
 
@@ -203,20 +203,20 @@ starburst_config(
 
 # Costs shown transparently
 results <- starburst_map(data, fn, workers = 100)
-#> 💰 Estimated cost: ~$3.50/hour
-#> ✓ Completed in 23 minutes
-#> 💰 Estimated cost: $1.34
+#> [Starting] Starting starburst cluster with 100 workers
+#> [OK] Completed in 1380.0 seconds
+#> [Cost] Estimated cost: $1.34
 ```
 
 ## Quota Management
 
-staRburst automatically handles AWS Fargate quota limitations:
+When using the Fargate backend, staRburst automatically handles AWS Fargate vCPU
+quota limits (EC2 uses your standard On-Demand/Spot limits):
 
 ```{r}
-results <- starburst_map(data, fn, workers = 100, cpu = 4)
-#> ⚠ Requested 100 workers (400 vCPUs) but quota allows 25 workers (100 vCPUs)
-#> ⚠ Using 25 workers instead
-#> 💰 Estimated cost: ~$1.40/hour
+results <- starburst_map(data, fn, workers = 100, cpu = 4, launch_type = "FARGATE")
+#> [!] Requested 100 workers (400 vCPUs) but quota allows 25 workers (100 vCPUs)
+#> [!] Using 25 workers instead
 ```
 
 Your work still completes, just with fewer workers. You can request quota increases through AWS Service Quotas.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ remotes::install_github("scttfrdmn/starburst")
 ``` r
 library(starburst)
 
-# One-time setup (2 minutes)
+# One-time setup (~2 min to provision; first run also builds the worker image,
+# +5-10 min once)
 starburst_setup()
 
 # Run parallel computation on AWS
@@ -61,16 +62,12 @@ results <- starburst_map(
   function(x) expensive_computation(x),
   workers = 50
 )
-#> 🚀 Starting starburst cluster with 50 workers
-#> 💰 Estimated cost: ~$2.80/hour
-#> 📊 Processing 1000 items with 50 workers
-#> 📦 Created 50 chunks (avg 20 items per chunk)
-#> 🚀 Submitting tasks...
-#> ✓ Submitted 50 tasks
-#> ⏳ Progress: 50/50 tasks (3.2 minutes elapsed)
-#>
-#> ✓ Completed in 3.2 minutes
-#> 💰 Estimated cost: $0.15
+#> [Starting] Starting starburst cluster with 50 workers
+#> [Status] Processing 1000 items with 50 workers
+#> [Starting] Submitting 1000 tasks...
+#> [Wait] Progress: 1000/1000 (192.0s)
+#> [OK] Completed in 192.0 seconds
+#> [Cost] Estimated cost: $0.15
 ```
 
 ## Example: Monte Carlo Simulation
@@ -96,13 +93,12 @@ results <- starburst_map(
   simulate_portfolio,
   workers = 100
 )
-#> 🚀 Starting starburst cluster with 100 workers
-#> 💰 Estimated cost: ~$5.60/hour
-#> 📊 Processing 10000 items with 100 workers
-#> ⏳ Progress: 100/100 tasks (3.1 minutes elapsed)
-#>
-#> ✓ Completed in 3.1 minutes
-#> 💰 Estimated cost: $0.29
+#> [Starting] Starting starburst cluster with 100 workers
+#> [Status] Processing 10000 items with 100 workers
+#> [Starting] Submitting 10000 tasks...
+#> [Wait] Progress: 10000/10000 (186.0s)
+#> [OK] Completed in 186.0 seconds
+#> [Cost] Estimated cost: $0.29
 
 # Extract results
 final_values <- sapply(results, function(x) x$final_value)
@@ -183,17 +179,22 @@ session$cleanup(force = TRUE)
 ## How It Works
 
 1.  **Environment Snapshot**: Captures your R packages using renv
-2.  **Container Build**: Creates Docker image with your environment,
+2.  **Container Build**: Creates a Docker image with your environment,
     cached in ECR
-3.  **Task Distribution**: Splits data into chunks across workers
-4.  **Task Submission**: Launches Fargate tasks (or sequential batches
-    if quota-limited)
-5.  **Data Transfer**: Serializes task data to S3 using fast qs format
-6.  **Execution**: Workers pull data, execute function on chunk items,
-    push results
-7.  **Result Collection**: Downloads and combines results in correct
-    order
-8.  **Cleanup**: Automatically shuts down workers
+3.  **Task Creation**: Creates one task per element of your input (`.x`)
+    — there is no automatic chunking; batch small items yourself if
+    per-task overhead matters
+4.  **Worker Launch**: Starts EC2 workers by default (Spot-enabled), or
+    Fargate tasks if you pass `launch_type = "FARGATE"`; falls back to
+    waves if quota-limited
+5.  **Data Transfer**: Serializes each task’s function, inputs, and
+    globals to S3 using the fast `qs2` format
+6.  **Execution**: Each worker pulls a task from S3, runs your function,
+    pushes the result back to S3
+7.  **Result Collection**: Downloads and combines results in the
+    original order
+8.  **Cleanup**: Automatically shuts workers down (warm-pool timeout
+    configurable)
 
 ## Cost Management
 
@@ -206,20 +207,21 @@ starburst_config(
 
 # Costs shown transparently
 results <- starburst_map(data, fn, workers = 100)
-#> 💰 Estimated cost: ~$3.50/hour
-#> ✓ Completed in 23 minutes
-#> 💰 Estimated cost: $1.34
+#> [Starting] Starting starburst cluster with 100 workers
+#> [OK] Completed in 1380.0 seconds
+#> [Cost] Estimated cost: $1.34
 ```
 
 ## Quota Management
 
-staRburst automatically handles AWS Fargate quota limitations:
+When using the Fargate backend, staRburst automatically handles AWS
+Fargate vCPU quota limits (EC2 uses your standard On-Demand/Spot
+limits):
 
 ``` r
-results <- starburst_map(data, fn, workers = 100, cpu = 4)
-#> ⚠ Requested 100 workers (400 vCPUs) but quota allows 25 workers (100 vCPUs)
-#> ⚠ Using 25 workers instead
-#> 💰 Estimated cost: ~$1.40/hour
+results <- starburst_map(data, fn, workers = 100, cpu = 4, launch_type = "FARGATE")
+#> [!] Requested 100 workers (400 vCPUs) but quota allows 25 workers (100 vCPUs)
+#> [!] Using 25 workers instead
 ```
 
 Your work still completes, just with fewer workers. You can request

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -59,15 +59,57 @@ navbar:
       text: News
       href: news/index.html
 
-# Let pkgdown auto-generate the reference index
-# Manually organizing 29+ exported functions is error-prone
-# reference:
-# - title: "Main Functions"
-#   desc: "Core functions for cloud bursting"
-#   contents:
-#   - starburst_map
-#   - starburst_cluster
-#   - starburst_setup
+# Grouped reference index. Only the user-facing exports are listed here, in the
+# order a reader should discover them; the trailing internal/developer group keeps
+# the future-backend S3 methods out of the way. Anything exported but not listed
+# still appears under an auto-generated "undocumented"/other section, so this is
+# additive, not a coverage risk.
+reference:
+- title: "Start here"
+  desc: "Set up once, then run your first job."
+  contents:
+  - starburst-package
+  - starburst_setup
+  - starburst_is_configured
+- title: "Core execution"
+  desc: "Run work across AWS workers."
+  contents:
+  - starburst_map
+  - starburst_cluster
+- title: "future / furrr integration"
+  desc: "Use staRburst as a future backend for existing future/furrr code."
+  contents:
+  - plan.starburst
+  - starburst
+- title: "Detached sessions"
+  desc: "Long-running jobs that survive your R session closing."
+  contents:
+  - starburst_session
+  - starburst_session_attach
+  - starburst_list_sessions
+- title: "Configuration"
+  desc: "Account and backend defaults."
+  contents:
+  - starburst_config
+  - starburst_status
+- title: "Monitoring, logs & cost"
+  contents:
+  - starburst_logs
+  - starburst_estimate
+  - starburst_quota_status
+  - starburst_check_quota_request
+  - starburst_request_quota_increase
+- title: "Infrastructure setup"
+  desc: "One-time provisioning and maintenance."
+  contents:
+  - starburst_setup_ec2
+  - starburst_rebuild_environment
+  - starburst_cleanup_ecr
+- title: "Developer & internal"
+  desc: "Extension points and future-backend internals; not needed for normal use."
+  contents:
+  - StarburstBackend
+  - StarburstFuture
 
 articles:
 - title: "Getting Started"

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -110,6 +110,15 @@ reference:
   contents:
   - StarburstBackend
   - StarburstFuture
+  - future.starburst
+  - launchFuture.StarburstBackend
+  - listFutures.StarburstBackend
+  - nbrOfWorkers.StarburstBackend
+  - resolved.StarburstFuture
+  - result.StarburstFuture
+  - run.StarburstFuture
+  - print.StarburstSessionStatus
+  - session-api
 
 articles:
 - title: "Getting Started"

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,14 +92,23 @@ Use these for benchmarking and validation.
 
 ## Performance Expectations
 
-Typical speedups with 50-100 workers:
-- Monte Carlo: 30-50x speedup
-- Bootstrap: 20-40x speedup
-- Data Processing: 15-30x speedup
-- Grid Search: 25-40x speedup
+> **Read the runtimes above honestly.** The "with N workers" figures are
+> **compute-only on a warm worker pool** — they exclude the one-time cluster
+> startup (~2 minutes) and image pull. For the small, seconds-scale demos here,
+> that startup dominates and **running locally is faster overall**. These examples
+> are sized to run quickly for illustration, not to show a net win.
+>
+> Cloud bursting pays off when each task runs for **minutes** and there are many of
+> them, so the fixed startup is amortized away. See `vignette("performance")` for
+> the sizing heuristics (roughly: tasks under ~30 min of total local work often
+> aren't worth bursting).
+
+Speedup potential at scale (compute-only, once workers are warm — not net of
+startup) with 50–100 workers:
+- Monte Carlo, Bootstrap, Data Processing, Grid Search all parallelize near-linearly
 
 Actual performance depends on:
-- Task granularity
-- Data transfer overhead
-- Network conditions
+- Task granularity (bigger per-task work amortizes startup better)
+- Whether the pool is cold or warm, and whether provisioning is counted
+- Data transfer overhead and network conditions
 - AWS region and availability

--- a/man/starburst_cluster.Rd
+++ b/man/starburst_cluster.Rd
@@ -10,7 +10,10 @@ starburst_cluster(
   memory = "8GB",
   platform = "X86_64",
   region = NULL,
-  timeout = 3600
+  timeout = 3600,
+  launch_type = "EC2",
+  instance_type = "c7g.xlarge",
+  use_spot = TRUE
 )
 }
 \arguments{
@@ -25,6 +28,13 @@ starburst_cluster(
 \item{region}{AWS region}
 
 \item{timeout}{Maximum runtime in seconds}
+
+\item{launch_type}{Compute backend: "EC2" (default) or "FARGATE"}
+
+\item{instance_type}{EC2 instance type when \code{launch_type = "EC2"}
+(default: "c7g.xlarge")}
+
+\item{use_spot}{Use EC2 Spot instances for cost savings (default: TRUE)}
 }
 \value{
 A starburst_cluster object
@@ -38,6 +48,9 @@ using the staRburst Future backend.
 if (starburst_is_configured()) {
   cluster <- starburst_cluster(workers = 20)
   results <- cluster$map(data, function(x) x * 2)
+
+  # Fargate backend instead of the EC2 default
+  fg <- starburst_cluster(workers = 20, launch_type = "FARGATE")
 }
 }
 }

--- a/man/starburst_config.Rd
+++ b/man/starburst_config.Rd
@@ -12,27 +12,54 @@ starburst_config(
 )
 }
 \arguments{
-\item{max_cost_per_job}{Maximum cost per job in dollars}
+\item{max_cost_per_job}{Maximum estimated cost (USD) for a single job. Jobs whose
+estimate exceeds this error before launching. \code{NULL} leaves it unchanged.}
 
-\item{cost_alert_threshold}{Cost threshold for alerts}
+\item{cost_alert_threshold}{Estimated cost (USD) at which a warning is emitted.
+\code{NULL} leaves it unchanged.}
 
-\item{auto_cleanup_s3}{Automatically clean up S3 files after completion}
+\item{auto_cleanup_s3}{Logical; automatically delete a job's S3 task/result
+objects after completion. \code{NULL} leaves it unchanged.}
 
-\item{...}{Additional configuration options}
+\item{...}{Additional user-settable keys merged into the config. Recognized keys:
+\describe{
+  \item{\code{use_public_base}}{Logical; pull the public base image instead of
+    building a private one (see \code{\link{starburst_setup}}).}
+  \item{\code{ecr_image_ttl_days}}{Integer; lifecycle age at which cached ECR
+    images are expired.}
+}}
 }
 \value{
 Invisibly returns the updated configuration list.
 }
 \description{
-Configure staRburst options
+Reads and updates the persisted staRburst configuration. Call with no arguments
+to leave settings unchanged (it still returns the current config invisibly); pass
+one or more of the arguments below to update them.
+}
+\details{
+Other keys in the stored config are **infrastructure-managed** — written by
+\code{\link{starburst_setup}}/\code{\link{starburst_setup_ec2}} and not intended
+to be set by hand: \code{region}, \code{bucket}, \code{cluster},
+\code{ecr_repository}, \code{aws_account_id}, \code{execution_role_arn},
+\code{task_role_arn}, \code{subnets}, and \code{security_groups}. Use
+\code{\link{starburst_status}} to inspect the effective configuration read-only.
 }
 \examples{
 \donttest{
 if (starburst_is_configured()) {
+  # Update cost guardrails
   starburst_config(
     max_cost_per_job = 10,
     cost_alert_threshold = 5
   )
+
+  # Read the current config without changing anything
+  cfg <- starburst_config()
 }
 }
+}
+\seealso{
+\code{\link{starburst_status}} to view config without changing it;
+  \code{\link{starburst_setup}} for initial provisioning.
 }

--- a/man/starburst_map.Rd
+++ b/man/starburst_map.Rd
@@ -13,6 +13,9 @@ starburst_map(
   platform = "X86_64",
   region = NULL,
   timeout = 3600,
+  launch_type = "EC2",
+  instance_type = "c7g.xlarge",
+  use_spot = TRUE,
   .progress = TRUE,
   ...
 )
@@ -33,6 +36,13 @@ starburst_map(
 \item{region}{AWS region}
 
 \item{timeout}{Maximum runtime in seconds per task}
+
+\item{launch_type}{Compute backend: "EC2" (default) or "FARGATE"}
+
+\item{instance_type}{EC2 instance type when \code{launch_type = "EC2"}
+(default: "c7g.xlarge")}
+
+\item{use_spot}{Use EC2 Spot instances for cost savings (default: TRUE)}
 
 \item{.progress}{Show progress bar (default: TRUE)}
 
@@ -59,6 +69,10 @@ if (starburst_is_configured()) {
     cpu = 4,
     memory = "8GB"
   )
+
+  # Use the Fargate backend instead of the EC2 default
+  results <- starburst_map(1:100, function(x) x^2,
+                           workers = 10, launch_type = "FARGATE")
 }
 }
 }

--- a/man/starburst_session.Rd
+++ b/man/starburst_session.Rd
@@ -42,19 +42,47 @@ starburst_session(
 \item{warm_pool_timeout}{EC2 warm pool timeout in seconds (default: 3600)}
 }
 \value{
-A StarburstSession object with methods:
-  \itemize{
-    \item \code{submit(expr, ...)} - Submit a task to the session
-    \item \code{status()} - Get progress summary
-    \item \code{collect(wait = FALSE)} - Collect completed results
-    \item \code{extend(seconds = 3600)} - Extend timeout
-    \item \code{cleanup()} - Terminate and cleanup
+A \code{StarburstSession} object (also carrying \code{$session_id}, the
+  handle you pass to \code{\link{starburst_session_attach}}) with methods:
+  \describe{
+    \item{\code{submit(expr, globals = NULL, packages = NULL)}}{Submit one task
+      (a quoted expression). Returns the task id. Call repeatedly to fan out work.}
+    \item{\code{status()}}{Return a progress summary (counts of pending / running
+      / completed / failed tasks). Safe to call from a fresh R session after
+      reattaching.}
+    \item{\code{collect(wait = FALSE)}}{Retrieve results. With \code{wait = FALSE}
+      returns whatever has completed so far; with \code{wait = TRUE} blocks until
+      all submitted tasks finish. Results come back in submission order.}
+    \item{\code{extend(seconds = 3600)}}{Extend the active/absolute timeout of a
+      still-running session.}
+    \item{\code{cleanup()}}{Stop all tasks/workers for the session and delete its
+      S3 objects. Call when done; otherwise the session self-terminates at
+      \code{absolute_timeout}.}
   }
 }
 \description{
 Creates a new detached session that can run computations independently
 of your R session. You can close R and reattach later to collect results.
 }
+\section{Lifecycle}{
+
+\code{starburst_session()} launches workers immediately and returns a handle.
+Submit tasks, then either poll \code{status()}/\code{collect()} in the same
+session, or record \code{session$session_id}, close R, and later
+\code{\link{starburst_session_attach}(session_id)} to reconnect and collect.
+A session ends when you call \code{cleanup()}, when \code{session_timeout}
+elapses with no activity, or at \code{absolute_timeout} — whichever comes first.
+}
+
+\section{Failure behavior}{
+
+A failed task is recorded (surfaced via \code{status()}) and does not abort the
+others; its error is raised when you \code{collect()} that result. If the client
+dies, workers keep running against S3 until a timeout, which is what makes
+reattaching possible. \code{cleanup()} is the only thing that frees resources
+early — sessions do not auto-clean on garbage collection.
+}
+
 \examples{
 \donttest{
 if (starburst_is_configured()) {
@@ -76,4 +104,9 @@ if (starburst_is_configured()) {
   results <- session$collect(wait = TRUE)
 }
 }
+}
+\seealso{
+\code{\link{starburst_session_attach}},
+  \code{\link{starburst_list_sessions}}; \code{\link{starburst_map}} for
+  ephemeral (non-detached) fan-out.
 }

--- a/tests/testthat/test-plan.R
+++ b/tests/testthat/test-plan.R
@@ -22,3 +22,38 @@ test_that("plan.starburst creates valid plan object", {
   expect_equal(plan$workers, 10)
   expect_equal(plan$cpu, 4)
 })
+
+test_that("starburst_map and starburst_cluster expose backend override args", {
+  # Guards against the regression where the changelog promised launch_type/
+  # instance_type/use_spot on these functions but the signatures lacked them
+  # (so the args silently fell into ... and were passed to .f).
+  for (fn in list(starburst_map, starburst_cluster)) {
+    args <- names(formals(fn))
+    expect_true(all(c("launch_type", "instance_type", "use_spot") %in% args))
+    expect_identical(eval(formals(fn)$launch_type), "EC2")
+    expect_identical(eval(formals(fn)$use_spot), TRUE)
+  }
+})
+
+test_that("starburst_map forwards backend overrides to plan.starburst", {
+  skip_if_not_installed("mockery")
+
+  captured <- NULL
+  # Stop execution right after plan.starburst is called by throwing a sentinel,
+  # so the test never touches AWS/future.
+  mockery::stub(starburst_map, "plan.starburst", function(...) {
+    captured <<- list(...)
+    stop("stop-after-plan")
+  })
+  mockery::stub(starburst_map, "get_starburst_config", function() list(region = "us-east-1"))
+
+  expect_error(
+    starburst_map(1:3, function(x) x,
+                  launch_type = "FARGATE", instance_type = "c6a.large",
+                  use_spot = FALSE, .progress = FALSE),
+    "stop-after-plan"
+  )
+  expect_equal(captured$launch_type, "FARGATE")
+  expect_equal(captured$instance_type, "c6a.large")
+  expect_false(captured$use_spot)
+})

--- a/vignettes/detached-sessions.Rmd
+++ b/vignettes/detached-sessions.Rmd
@@ -35,7 +35,7 @@ For analyses that take hours or days:
 ```{r}
 library(starburst)
 
-# Create a detached session
+# Create a detached session (EC2 workers with Spot by default)
 session <- starburst_session(
   workers = 10,
   cpu = 4,
@@ -127,20 +127,27 @@ session$extend(seconds = 3600)
 session$cleanup()
 ```
 
-## Advanced Usage
+## Choosing and tuning the backend
 
-### EC2 Launch Type
-
-For better price/performance:
+Sessions use **EC2 with Spot instances by default** — no extra arguments needed.
+You can tune the instance type, or opt into Fargate:
 
 ```{r}
+# Default is already EC2 + Spot; override the instance type if you like
 session <- starburst_session(
   workers = 50,
-  launch_type = "EC2",
-  instance_type = "c8a.xlarge",  # AMD 8th gen
-  use_spot = TRUE                 # 70% cheaper
+  instance_type = "c8a.xlarge",  # AMD 8th gen; default is c7g.xlarge
+  use_spot = TRUE                 # default TRUE — ~70% cheaper
+)
+
+# Opt into the Fargate backend (serverless, task-based) instead
+session <- starburst_session(
+  workers = 50,
+  launch_type = "FARGATE"
 )
 ```
+
+## Advanced Usage
 
 ### Error Handling
 

--- a/vignettes/example-feature-engineering.Rmd
+++ b/vignettes/example-feature-engineering.Rmd
@@ -328,16 +328,22 @@ Average online rate: 28.9%
 
 ## Performance Comparison
 
-| Method | Customers | Time | Cost | Speedup |
-|--------|-----------|------|------|---------|
-| Local | 500 | 3.8 sec | $0 | - |
-| Local (est.) | 5,000 | 38 sec | $0 | 1x |
-| staRburst | 5,000 | 6.2 sec | $0.003 | 6.1x |
+| Method | Customers | Compute time | Cost |
+|--------|-----------|------|------|
+| Local | 500 | 3.8 sec | $0 |
+| Local (est.) | 5,000 | 38 sec | $0 |
+| staRburst | 5,000 | 6.2 sec (compute only) | $0.003 |
+
+> **Reading these numbers honestly:** the staRburst row is *compute time only* on a
+> warm pool and excludes the one-time startup (~2 minutes) and image pull. For a job
+> that finishes in ~38 seconds locally, that startup makes local the faster choice —
+> these figures are illustrative, not a net-win claim. The payoff comes at scale
+> (100K+ customers or heavier per-record work). See `vignette("performance")`.
 
 **Key Insights**:
-- Excellent parallelization efficiency (6x speedup)
-- Minimal cost for significant time savings
-- Scales well to larger datasets (100K+ customers)
+- Feature engineering parallelizes near-linearly once workers are warm
+- Minimal per-task cost
+- The win is at scale, where startup overhead is amortized away
 - Can process 100 customers/second with 20 workers
 
 ## Advanced: Adding ML-Ready Features

--- a/vignettes/example-reports.Rmd
+++ b/vignettes/example-reports.Rmd
@@ -328,18 +328,24 @@ Generated reports:
 
 ## Performance Comparison
 
-| Method | Reports | Time | Cost | Speedup |
+| Method | Reports | Compute time | Cost | Speedup |
 |--------|---------|------|------|---------|
 | Local | 50 | 3.9 min | $0 | 1x |
 | staRburst | 50 (10 workers) | 1.2 min | $0.004 | 3.3x |
 | staRburst | 50 (25 workers) | 0.4 min | $0.01 | 9.8x |
 | staRburst | 50 (50 workers) | 0.3 min | $0.02 | 13x |
 
+> **Disclosure:** staRburst rows are *compute time on a warm pool* and exclude the
+> one-time startup (~2 minutes) and image pull. Unlike the seconds-scale demos,
+> this workload is a genuine fit — each report takes 1–2 minutes, so even with
+> startup added the 25–50-worker runs come out well ahead of the 3.9-minute local
+> baseline, and more so at 500+ reports.
+
 **Key Insights**:
 - Near-linear scaling with worker count
 - Sweet spot: 25-50 workers for this workload
 - Minimal cost ($0.01) for significant time savings
-- Can easily scale to 500+ reports
+- A good fit for bursting because per-report work is minutes, not seconds
 
 ## Advanced: Custom Report Distribution
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -137,7 +137,7 @@ results <- starburst_map(1:100, expensive_simulation, workers = 50)
 That is the whole workflow: `starburst_setup()` once, then `starburst_map()` per
 job. Everything below builds on this.
 
-## Migrating existing `future` / `furrr` code
+## Migrating existing `future` / `furrr` code {#migrating-existing-future-furrr-code}
 
 If you already use `future` or `furrr`, you don't need `starburst_map()` — set the
 plan to `starburst` and your existing `future_map()` / `future_lapply()` calls run

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -32,9 +32,10 @@ fits how your code is written:
 | Explicit, reusable worker cluster | `starburst_cluster()` |
 | Configure account/backend defaults | `starburst_config()` |
 
-If you're new, start with `starburst_map()`. This guide uses the `future`/`furrr`
-integration (`plan(starburst)`) for most examples because it drops into existing
-future-based code unchanged; every example works with `starburst_map()` too.
+If you're new, start with `starburst_map()` — the next section walks through a
+first job with it. If you already have `future`/`furrr` code, skip to
+[Migrating existing future / furrr code](#migrating-existing-future-furrr-code);
+the two styles are equivalent and shown side by side there.
 
 ## Installation
 
@@ -67,12 +68,12 @@ staRburst also builds the worker Docker image, which adds **5–10 minutes** (it
 cached and reused afterwards, and you can skip it with
 `starburst_setup(build_image = FALSE)` and build lazily on first job launch).
 
-## Basic Usage
+## Your first job
 
-The simplest way to use staRburst is with the `furrr` package:
+The simplest way to use staRburst is `starburst_map()` — hand it your inputs and a
+function, and it runs the function over each input on AWS workers:
 
 ```{r}
-library(furrr)
 library(starburst)
 
 # Define your work
@@ -85,24 +86,51 @@ expensive_simulation <- function(i) {
   mean(results)
 }
 
-# Local execution (single core)
+# Run across 50 cloud workers (EC2 by default)
+results <- starburst_map(1:100, expensive_simulation, workers = 50)
+#> [Starting] Starting starburst cluster with 50 workers
+#> [Status] Processing 100 items with 50 workers
+#> [Starting] Submitting 100 tasks...
+#> [Wait] Progress: 100/100 (128.0s)
+#> [OK] Completed in 128.0 seconds
+#> [Cost] Estimated cost: $0.85
+```
+
+That is the whole workflow: `starburst_setup()` once, then `starburst_map()` per
+job. Everything below builds on this.
+
+## Migrating existing `future` / `furrr` code
+
+If you already use `future` or `furrr`, you don't need `starburst_map()` — set the
+plan to `starburst` and your existing `future_map()` / `future_lapply()` calls run
+on AWS unchanged. The two styles are equivalent; use whichever matches your code:
+
+```{r}
+library(furrr)
+library(starburst)
+
+# Local baseline
 plan(sequential)
-system.time({
-  results_local <- future_map(1:100, expensive_simulation)
-})
-#> ~16 minutes on typical laptop
+results_local <- future_map(1:100, expensive_simulation)
 
-# Cloud execution (50 workers)
+# Same code, now on 50 cloud workers — just change the plan
 plan(starburst, workers = 50)
-system.time({
-  results_cloud <- future_map(1:100, expensive_simulation)
-})
-#> ~2 minutes (including 45s startup)
-#> Cost: ~$0.85
+results_cloud <- future_map(1:100, expensive_simulation)
 
-# Results are identical
+# Results are identical to the local run
 identical(results_local, results_cloud)
 #> [1] TRUE
+```
+
+The two calls below do the same thing — pick the one that fits your codebase:
+
+```{r}
+# Direct API
+results <- starburst_map(1:100, expensive_simulation, workers = 50)
+
+# future / furrr
+plan(starburst, workers = 50)
+results <- future_map(1:100, expensive_simulation)
 ```
 
 ## Example 1: Monte Carlo Simulation
@@ -309,7 +337,11 @@ results <- future_map(data, process)
 #> Total cost: $1.34
 ```
 
-## Quota Management
+## Quota Management (Fargate backend)
+
+> This section applies to the **Fargate** backend. On the default **EC2** backend,
+> worker count is bounded by your normal EC2 On-Demand / Spot instance limits, not
+> the Fargate vCPU quota below. If you stay on EC2 you can usually skip this.
 
 ### Check Your Quota
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -37,6 +37,44 @@ first job with it. If you already have `future`/`furrr` code, skip to
 [Migrating existing future / furrr code](#migrating-existing-future-furrr-code);
 the two styles are equivalent and shown side by side there.
 
+## How it works (the mental model)
+
+```
+        Local R session
+              |
+              |  (1) serialize your function + inputs + detected globals (qs2)
+              |      AWS credentials are read HERE, from your local environment
+              v
+   S3 bucket  +  staRburst control plane (ECS/ECR)
+              |
+              |  (2) launch workers: EC2 (default, Spot) or Fargate
+              |      each worker's R packages come from your renv.lock, baked
+              |      into a Docker image cached in ECR
+              v
+   Remote R workers  (one task per input element)
+              |
+              |  (3) each worker pulls a task from S3, runs it, writes the
+              |      result + logs back to S3
+              v
+   Local R session  <-- results collected in order (starburst_map / cluster)
+        or
+   Detached-session store in S3  <-- collected later via starburst_session_attach()
+```
+
+**What to know from this picture:**
+
+- **Credentials** are used only on your machine (to call AWS) and by the workers'
+  IAM role — you never put keys in your code or in S3.
+- **Uploaded** per task: your function, its inputs, and auto-detected globals — not
+  your whole workspace. Large data should go to S3 yourself and be read on the worker.
+- **Dependencies** come from your `renv.lock`, installed into the worker image once
+  and cached in ECR (this is the first-run build cost).
+- **After a failure or disconnect**, workers keep running against S3 until a
+  timeout; nothing is silently lost. `session$cleanup()` (or normal completion of
+  `starburst_map()`) tears down workers and removes the job's S3 objects.
+- **Detached sessions** differ only in step 3's return path: results persist in S3
+  so you can close R and collect later, instead of blocking the local session.
+
 ## Installation
 
 ```{r}


### PR DESCRIPTION
Addresses the second documentation review (which raised the docs 6→7.7/10). Verified every claim against source first. Highest item was a real correctness bug, not presentation.

## Correctness (the #1 item)
**`starburst_map()` / `starburst_cluster()` now accept and forward `launch_type` / `instance_type` / `use_spot`.** The 0.3.7 migration note said users could pass `launch_type = "FARGATE"` to these functions, but they had no such argument — the value fell into `...` and was passed to the mapped function `.f` (unused-argument error), never switching the backend. Added the params, forwarded to `plan.starburst()` (which already honors them), added tests (signature + forwarding via mockery, no AWS). New **0.3.9 (development)** NEWS entry; DESCRIPTION bumped to 0.3.9.

## Remaining drift
- **README** regenerated from `README.Rmd`: emoji/'Created N chunks'/'Submitting 50 tasks' fake output → real ASCII engine output with correct per-element task counts; 'How It Works' rewritten (one task per element, EC2-default launch, qs2, warm-pool cleanup); quota section scoped to Fargate.
- **Getting Started** now leads with `starburst_map()`; `future`/`furrr` moved to a clearly-second migration section with side-by-side paired examples (replacing 'every example works with starburst_map() too').
- **EC2-primary framing**: getting-started quota section scoped to Fargate (EC2 uses normal instance limits); detached-sessions no longer files EC2 under 'Advanced' — EC2+Spot is presented as the default, Fargate as opt-in.
- **Benchmark disclosures**: warm/compute-only, excludes-startup caveats added to examples/README and the feature-engineering + reports vignette tables (reports labeled a genuine fit; the rest illustrative). Geospatial/bootstrap were already done in #33.
- **Reference index** grouped in `_pkgdown.yml` (Start here / Core / future-furrr / Sessions / Config / Monitoring / Setup / Developer&internal), keeping backend internals out of the way.
- **`starburst_config()`** now documents the full user-settable key catalogue + which keys are infrastructure-managed; **`starburst_session()`** expanded with per-method args/returns + Lifecycle / Failure-behavior / cleanup sections.
- **Architecture diagram** added to Getting Started (local → S3/control plane → workers → results/detached store), labeling credentials, uploads, deps, failure residue, cleanup, and how detached differs. **Closes #34.**

## Verification
- `devtools::check()` → **0 errors / 0 warnings / 0 notes**.
- `tools/check-docs.R` passes; new launch_type tests pass (14 pass / 1 AWS-skip).
- grep sweep for future_starburst / yourname / starburst_upload / chunks / emoji → clean.

The reproducible cold/warm benchmark harness (review point 5's full version) remains tracked in #35.