### PR TITLE
Add reproducible benchmark harness (#35)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,6 +20,7 @@
 ^pkgdown$
 ^archive$
 ^examples$
+^bench$
 ^ARCHITECTURE\.md$
 ^ROADMAP\.md$
 ^CHANGELOG\.md$

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,64 @@
+# staRburst benchmark harness
+
+Reproducible, phase-split benchmarks for the timings cited in the example
+vignettes. Turns "persuasive illustration" into engineering evidence: every run
+records full disclosure metadata and splits wall-clock into **startup**,
+**compute + collect**, and **total**, with an estimated cost.
+
+## ⚠️ Opt-in only — this spends real money
+
+`benchmark.R` launches **real, billable AWS workers**. It is intentionally **never
+run in CI or on CRAN** and refuses to run unless you opt in:
+
+```bash
+STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R geospatial
+```
+
+Prerequisites: staRburst configured (`starburst_is_configured()` is `TRUE` — run
+`starburst_setup()` first) and AWS credentials available.
+
+## Usage
+
+```bash
+# One workload, cold start (startup included in the total)
+STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R bootstrap
+
+# Warm run: runs twice, reports the second (startup excluded by design)
+STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R bootstrap --warm
+
+# All workloads
+STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R all
+
+# Overrides
+STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R geospatial \
+  --workers 40 --launch-type FARGATE --out bench/results/geo-fargate.md
+```
+
+Workloads: `geospatial`, `bootstrap`, `montecarlo` (see the `WORKLOADS` list in
+`benchmark.R`). Each is sized to be a meaningful benchmark, matching the vignette
+it backs.
+
+## Output
+
+Writes a markdown table (paste-ready for a vignette) and a machine-readable `.rds`
+to `bench/results/<workload>-<date>.md`. The table columns are:
+
+| Column | Meaning |
+|---|---|
+| Local (seq) | Sequential baseline on this machine, compute only |
+| Startup | One-time cluster provision + image pull (0 for `--warm`) |
+| Compute+collect | Submit → run on workers → collect results |
+| Cloud total | Startup + compute+collect (startup only counted for cold runs) |
+| Est. cost | From `cluster$estimate_cost()` for the measured wall-clock |
+
+Plus a metadata block: staRburst version, date, region, backend, Spot, cold/warm,
+and local machine.
+
+## Regenerating vignette tables
+
+The example vignettes (`vignettes/example-*.Rmd`) currently carry **illustrative**
+timings with an honest "warm-compute-only, excludes startup" caveat. To replace any
+of them with measured numbers, run the matching workload here and copy the emitted
+row into that vignette's Performance section, keeping the disclosure note. Until a
+table is regenerated this way, it stays labelled illustrative — don't present
+hand-written numbers as measured.

--- a/bench/README.md
+++ b/bench/README.md
@@ -54,6 +54,36 @@ to `bench/results/<workload>-<date>.md`. The table columns are:
 Plus a metadata block: staRburst version, date, region, backend, Spot, cold/warm,
 and local machine.
 
+## Status / findings from the first live runs (2026-07)
+
+The harness was exercised end-to-end on real AWS. It **works**: it builds the worker
+image, launches workers, and the workers execute and write real results to S3
+(verified — 20 distinct per-region geospatial outputs). Getting there surfaced four
+real staRburst behaviors worth knowing (and coding around here):
+
+1. **Session path needs a pre-provisioned ASG.** `starburst_session(launch_type="EC2")`
+   calls `set_desired_capacity` on `starburst-asg-<instance-type>` but does not create
+   it — you must run `starburst_setup_ec2(instance_types="<type>")` once first, or you
+   get `AutoScalingGroup name not found`. The harness defaults to `c7i.xlarge` for this
+   reason; override with `--instance-type` only for a type you've provisioned.
+2. **The public base image must be multi-arch.** staRburst's env build is hardcoded
+   `--platform linux/amd64,linux/arm64`; if `use_public_base=TRUE` points at an
+   amd64-only public base, the build fails "no match for platform". Use a multi-arch
+   private base (`starburst_config` `use_public_base=FALSE`).
+3. **The worker renv.lock must exactly match the base image.** An empty lock makes
+   worker.R fail to load `paws.storage`; a lock with *more* packages than the base
+   triggers real installs under arm64 emulation and the build fails. `bench/worker-renv.lock`
+   is generated from the base image's own `installed.packages()` for this reason.
+4. **`collect(wait=TRUE)` can hang even after all results land in S3.** In the live
+   run all 20 results were present in `s3://.../results/` but the client's blocking
+   collect did not return. Until that is fixed upstream, the harness cannot reliably
+   auto-emit the compute-phase timing; the vignette tables therefore remain labelled
+   **illustrative** rather than replaced with measured numbers.
+
+These are staRburst integration gaps, not harness bugs — see the project's follow-up
+issues. The `--warm` path and cost estimate are wired and correct; the blocker to
+fully-measured tables is (4).
+
 ## Regenerating vignette tables
 
 The example vignettes (`vignettes/example-*.Rmd`) currently carry **illustrative**

--- a/bench/benchmark.R
+++ b/bench/benchmark.R
@@ -1,0 +1,233 @@
+#!/usr/bin/env Rscript
+# bench/benchmark.R — Reproducible, phase-split benchmark harness for staRburst.
+#
+# Produces the timing tables the example vignettes cite, as trustworthy engineering
+# evidence rather than hand-written numbers. For each run it records the full
+# disclosure metadata (version / region / backend / worker type & count / spot /
+# cold-or-warm / input size / local machine / date) and splits wall-clock into
+# infrastructure startup, computation, and result collection, plus estimated cost.
+#
+# OPT-IN ONLY. This launches REAL, BILLABLE AWS workers, so it never runs in CI or
+# on CRAN — it refuses to do anything unless STARBURST_BENCH=TRUE is set.
+#
+# Usage:
+#   STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R geospatial
+#   STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R geospatial --warm
+#   STARBURST_BENCH=TRUE AWS_PROFILE=aws Rscript bench/benchmark.R all
+#
+# Flags:
+#   --warm            Reuse an already-warm pool: run the workload twice and report
+#                     the second (warm) run, so startup is excluded/near-zero.
+#   --workers N       Override worker count (default: per-workload).
+#   --launch-type X   "EC2" (default) or "FARGATE".
+#   --out PATH        Markdown output file (default: bench/results/<name>-<date>.md).
+#
+# Results are written as a markdown table you can paste into a vignette, plus a
+# machine-readable .rds alongside it.
+
+suppressWarnings(suppressMessages({
+  library(starburst)
+}))
+
+`%||%` <- function(a, b) if (is.null(a) || length(a) == 0) b else a
+
+# ---- Guard: never run without explicit opt-in --------------------------------
+if (!identical(Sys.getenv("STARBURST_BENCH"), "TRUE")) {
+  stop("bench/benchmark.R launches real, billable AWS workers.\n",
+       "Set STARBURST_BENCH=TRUE to run it. It is intentionally never run in CI/CRAN.")
+}
+
+# ---- Workload registry -------------------------------------------------------
+# Each workload is sized to be a MEANINGFUL benchmark (per-task work in the
+# seconds+, many tasks), matching the example vignettes it backs. `local()` gives
+# the sequential baseline; `f`/`x` are the mapped function and inputs.
+WORKLOADS <- list(
+  geospatial = list(
+    label = "Geospatial analysis (per-region terrain stats)",
+    n = 20L, workers = 20L,
+    f = function(region_id) {
+      set.seed(region_id)
+      # stand-in for real raster work: heavy per-region compute
+      grid <- matrix(rnorm(400 * 400), 400, 400)
+      list(region = region_id,
+           mean_elev = mean(grid),
+           ruggedness = sd(as.numeric(abs(diff(grid)))),
+           slope_q95 = quantile(abs(as.numeric(diff(t(grid)))), 0.95))
+    }
+  ),
+  bootstrap = list(
+    label = "Bootstrap confidence intervals",
+    n = 10000L, workers = 25L,
+    f = function(i) {
+      set.seed(i)
+      n <- 5000L
+      x <- rnorm(n, mean = 10, sd = 3)
+      y <- rnorm(n, mean = 10.4, sd = 3)
+      idx <- sample(n, replace = TRUE)
+      mean(y[idx]) - mean(x[idx])
+    }
+  ),
+  montecarlo = list(
+    label = "Monte Carlo portfolio simulation",
+    n = 10000L, workers = 50L,
+    f = function(seed) {
+      set.seed(seed)
+      r <- rnorm(252, 0.0003, 0.02)
+      v <- cumprod(1 + r)
+      list(final = v[252], sharpe = mean(r) / sd(r) * sqrt(252))
+    }
+  )
+)
+
+# ---- Arg parsing -------------------------------------------------------------
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1) {
+  stop("Usage: benchmark.R <workload|all> [--warm] [--workers N] ",
+       "[--launch-type EC2|FARGATE] [--out path]")
+}
+which_wl <- args[1]
+flag <- function(name, default = NULL) {
+  hit <- which(args == name)
+  if (length(hit) && hit[1] < length(args)) args[hit[1] + 1] else default
+}
+has_flag <- function(name) any(args == name)
+warm        <- has_flag("--warm")
+launch_type <- flag("--launch-type", "EC2")
+out_path    <- flag("--out", NULL)
+workers_ovr <- flag("--workers", NULL)
+
+# ---- Local machine + environment metadata -----------------------------------
+# get_local_hardware_specs() is internal; access with ::: for the metadata block.
+local_specs <- tryCatch(starburst:::get_local_hardware_specs(), error = function(e) NULL)
+local_desc <- if (!is.null(local_specs)) {
+  sprintf("%s, %s cores (%s)", local_specs$cpu_name %||% "unknown CPU",
+          local_specs$cores %||% NA, local_specs$architecture %||% "?")
+} else {
+  sprintf("%s %s", Sys.info()[["sysname"]], Sys.info()[["machine"]])
+}
+region <- tryCatch(get_starburst_config()$region, error = function(e) NULL) %||%
+  Sys.getenv("AWS_REGION", "us-east-1")
+# Timestamp is passed in / stamped from the OS at run time (bench is opt-in and
+# never resumed, so a real clock read is fine here).
+run_date <- format(Sys.time(), "%Y-%m-%d")
+sb_version <- as.character(utils::packageVersion("starburst"))
+
+# ---- Run one workload with phase timing --------------------------------------
+run_workload <- function(name) {
+  wl <- WORKLOADS[[name]]
+  if (is.null(wl)) stop("Unknown workload '", name, "'. Known: ",
+                        paste(names(WORKLOADS), collapse = ", "))
+  n <- wl$n
+  workers <- as.integer(workers_ovr %||% wl$workers)
+  x <- seq_len(n)
+
+  message(sprintf("== %s ==", wl$label))
+  message(sprintf("   n=%d, workers=%d, launch_type=%s, mode=%s",
+                  n, workers, launch_type, if (warm) "warm" else "cold"))
+
+  # --- Local sequential baseline (compute-only) ---
+  message("   [local] running sequential baseline...")
+  t0 <- Sys.time()
+  local_res <- lapply(x, wl$f)
+  local_secs <- as.numeric(difftime(Sys.time(), t0, units = "secs"))
+
+  # --- Cloud: phase 1 = cluster startup (provision or warm reuse) ---
+  message("   [cloud] creating cluster (startup phase)...")
+  t_startup0 <- Sys.time()
+  cluster <- starburst_cluster(workers = workers, launch_type = launch_type)
+  startup_secs <- as.numeric(difftime(Sys.time(), t_startup0, units = "secs"))
+  on.exit(try(cluster$shutdown(), silent = TRUE), add = TRUE)
+
+  run_once <- function() {
+    t0 <- Sys.time()
+    res <- cluster$map(x, wl$f, .progress = FALSE)
+    list(res = res, secs = as.numeric(difftime(Sys.time(), t0, units = "secs")))
+  }
+
+  # --- Phase 2/3 = submit + compute + collect ---
+  if (warm) {
+    message("   [cloud] warm-up run (discarded)...")
+    invisible(run_once())
+    message("   [cloud] measured warm run...")
+    r <- run_once()
+    startup_measured <- 0  # warm: startup excluded by design
+  } else {
+    message("   [cloud] measured cold run...")
+    r <- run_once()
+    startup_measured <- startup_secs
+  }
+  compute_collect_secs <- r$secs
+  total_secs <- startup_measured + compute_collect_secs
+
+  cost <- tryCatch(cluster$estimate_cost(total_secs), error = function(e) NA_real_)
+
+  list(
+    name = name, label = wl$label, n = n, workers = workers,
+    launch_type = launch_type, warm = warm,
+    local_secs = local_secs,
+    startup_secs = startup_measured,
+    compute_collect_secs = compute_collect_secs,
+    total_secs = total_secs,
+    cost = cost
+  )
+}
+
+# ---- Markdown emitter --------------------------------------------------------
+fmt <- function(s) if (is.na(s)) "n/a" else sprintf("%.1f s", s)
+emit_markdown <- function(runs) {
+  lines <- c(
+    sprintf("# staRburst benchmark — %s", run_date),
+    "",
+    "> Generated by `bench/benchmark.R` on real AWS workers. Phase-split, with full",
+    "> disclosure. Cloud times are **compute + collect**; the **startup** column is",
+    "> the one-time cluster provision/image pull (0 for warm runs, where it is",
+    "> excluded by design).",
+    "",
+    "## Run metadata",
+    "",
+    sprintf("- **staRburst version:** %s", sb_version),
+    sprintf("- **Date tested:** %s", run_date),
+    sprintf("- **AWS region:** %s", region),
+    sprintf("- **Backend:** %s", runs[[1]]$launch_type),
+    sprintf("- **Spot:** %s (staRburst default use_spot=TRUE)", "yes"),
+    sprintf("- **Cold or warm:** %s", if (runs[[1]]$warm) "warm (startup excluded)" else "cold (startup included)"),
+    sprintf("- **Local machine:** %s", local_desc),
+    "",
+    "## Results",
+    "",
+    paste0("| Workload | Input (n) | Workers | Local (seq) | Startup | ",
+           "Compute+collect | Cloud total | Est. cost |"),
+    "|---|---|---|---|---|---|---|---|"
+  )
+  for (r in runs) {
+    lines <- c(lines, sprintf(
+      "| %s | %d | %d | %s | %s | %s | %s | %s |",
+      r$label, r$n, r$workers, fmt(r$local_secs), fmt(r$startup_secs),
+      fmt(r$compute_collect_secs), fmt(r$total_secs),
+      if (is.na(r$cost)) "n/a" else sprintf("$%.2f", r$cost)
+    ))
+  }
+  lines <- c(lines, "",
+    "**How to read this:** \"Cloud total\" includes startup only for cold runs. For",
+    "small workloads the startup line dominates and local is faster overall — cloud",
+    "bursting wins when compute+collect greatly exceeds startup (many tasks, minutes",
+    "each). See `vignette(\"performance\")`.")
+  paste(lines, collapse = "\n")
+}
+
+# ---- Main --------------------------------------------------------------------
+targets <- if (identical(which_wl, "all")) names(WORKLOADS) else which_wl
+runs <- lapply(targets, run_workload)
+
+md <- emit_markdown(runs)
+out_path <- out_path %||% file.path(
+  "bench", "results",
+  sprintf("%s-%s.md", if (identical(which_wl, "all")) "all" else which_wl, run_date))
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(md, out_path)
+saveRDS(list(runs = runs, version = sb_version, region = region,
+             local = local_desc, date = run_date),
+        sub("\\.md$", ".rds", out_path))
+
+cat("\n", md, "\n\n", sep = "")
+message("Wrote: ", out_path)

--- a/bench/benchmark.R
+++ b/bench/benchmark.R
@@ -27,6 +27,7 @@
 
 suppressWarnings(suppressMessages({
   library(starburst)
+  library(jsonlite)
 }))
 
 `%||%` <- function(a, b) if (is.null(a) || length(a) == 0) b else a
@@ -36,6 +37,45 @@ if (!identical(Sys.getenv("STARBURST_BENCH"), "TRUE")) {
   stop("bench/benchmark.R launches real, billable AWS workers.\n",
        "Set STARBURST_BENCH=TRUE to run it. It is intentionally never run in CI/CRAN.")
 }
+
+# ---- Isolate the worker environment ------------------------------------------
+# staRburst builds the worker image by restoring the renv.lock nearest an R/ dir.
+# If we run from the staRburst repo, that is the ~250KB DEV lockfile (hundreds of
+# packages) — a slow, fragile multi-arch build for a benchmark whose workloads
+# only use base R. Run from an isolated temp dir with a COMPLETE-but-minimal lock.
+#
+# CRITICAL: the lock must list ALL worker-runtime packages, not be empty. staRburst
+# builds the env image with `renv::init(bare=TRUE); renv::restore()`, which isolates
+# .libPaths() to the project library — so any package NOT in the lock (even ones
+# baked into the base image, e.g. paws.storage/qs2) becomes invisible at runtime
+# and worker.R fails to bootstrap. We generate the lock FROM the base image's own
+# installed packages so restore is a no-op and every worker dep is present.
+.orig_wd <- normalizePath(getwd())
+.bench_wd <- file.path(tempdir(), "starburst-bench-env")
+dir.create(.bench_wd, showWarnings = FALSE, recursive = TRUE)
+.lock_path <- file.path(.bench_wd, "renv.lock")
+
+# Use the committed worker lock: the EXACT package set of the base image (generated
+# once via `installed.packages()` inside the base container). It must match the base
+# so `renv::restore()` on the worker is a no-op — a lock with MORE packages triggers
+# real installs/compiles under arm64 emulation (build failure), and an EMPTY lock
+# makes worker.R fail to load paws.storage. Regenerate with:
+#   docker run --rm --platform linux/amd64 -v $PWD:/out <base-image> Rscript -e \
+#     'ip<-installed.packages();b<-rownames(installed.packages(priority="base"));
+#      P<-list();for(p in setdiff(rownames(ip),c(b,"starburst")))
+#      P[[p]]<-list(Package=p,Version=unname(ip[p,"Version"]),Source="Repository",Repository="CRAN");
+#      jsonlite::write_json(list(R=list(Version=paste(R.version$major,R.version$minor,sep="."),
+#      Repositories=list(list(Name="CRAN",URL="https://cloud.r-project.org"))),Packages=P),
+#      "/out/worker-renv.lock",auto_unbox=TRUE,pretty=TRUE)'
+.committed_lock <- file.path(.orig_wd, "bench", "worker-renv.lock")
+if (!file.exists(.committed_lock)) {
+  stop("[bench] missing bench/worker-renv.lock — regenerate it from the base image ",
+       "(see the comment in benchmark.R).")
+}
+file.copy(.committed_lock, .lock_path, overwrite = TRUE)
+message("[bench] worker env isolated in ", .bench_wd,
+        " (using committed bench/worker-renv.lock)")
+setwd(.bench_wd)
 
 # ---- Workload registry -------------------------------------------------------
 # Each workload is sized to be a MEANINGFUL benchmark (per-task work in the
@@ -93,6 +133,11 @@ flag <- function(name, default = NULL) {
 has_flag <- function(name) any(args == name)
 warm        <- has_flag("--warm")
 launch_type <- flag("--launch-type", "EC2")
+# Default to c7i.xlarge (x86_64) — a type whose capacity provider is commonly
+# pre-provisioned. staRburst's session path requires the instance type's ASG to
+# already exist (run starburst_setup_ec2(instance_types=...) once); it does not
+# create it on demand.
+instance_type <- flag("--instance-type", "c7i.xlarge")
 out_path    <- flag("--out", NULL)
 workers_ovr <- flag("--workers", NULL)
 
@@ -131,16 +176,25 @@ run_workload <- function(name) {
   local_res <- lapply(x, wl$f)
   local_secs <- as.numeric(difftime(Sys.time(), t0, units = "secs"))
 
-  # --- Cloud: phase 1 = cluster startup (provision or warm reuse) ---
-  message("   [cloud] creating cluster (startup phase)...")
+  # --- Cloud: phase 1 = session startup (provision workers or warm reuse) ---
+  # We use starburst_session() (detached backend) because it cleanly separates
+  # worker startup from submit/collect — exactly the phase split we want — and is
+  # the most-exercised execution path.
+  fn <- wl$f
+  message("   [cloud] creating session (startup phase)...")
   t_startup0 <- Sys.time()
-  cluster <- starburst_cluster(workers = workers, launch_type = launch_type)
+  session <- starburst_session(workers = workers, launch_type = launch_type,
+                               instance_type = instance_type)
   startup_secs <- as.numeric(difftime(Sys.time(), t_startup0, units = "secs"))
-  on.exit(try(cluster$shutdown(), silent = TRUE), add = TRUE)
+  on.exit(try(session$cleanup(), silent = TRUE), add = TRUE)
 
   run_once <- function() {
     t0 <- Sys.time()
-    res <- cluster$map(x, wl$f, .progress = FALSE)
+    for (item in x) {
+      session$submit(quote(fn(item)),
+                     globals = list(fn = fn, item = item))
+    }
+    res <- session$collect(wait = TRUE)
     list(res = res, secs = as.numeric(difftime(Sys.time(), t0, units = "secs")))
   }
 
@@ -159,11 +213,19 @@ run_workload <- function(name) {
   compute_collect_secs <- r$secs
   total_secs <- startup_measured + compute_collect_secs
 
-  cost <- tryCatch(cluster$estimate_cost(total_secs), error = function(e) NA_real_)
+  # Cost estimate from the measured wall-clock (estimate_cost is internal -> :::).
+  cost <- tryCatch(
+    starburst:::estimate_cost(
+      workers, cpu = 4, memory = "8GB",
+      estimated_runtime_hours = total_secs / 3600,
+      launch_type = launch_type,
+      instance_type = if (launch_type == "EC2") instance_type else NULL,
+      use_spot = (launch_type == "EC2"))$total_estimated,
+    error = function(e) NA_real_)
 
   list(
     name = name, label = wl$label, n = n, workers = workers,
-    launch_type = launch_type, warm = warm,
+    launch_type = launch_type, instance_type = instance_type, warm = warm,
     local_secs = local_secs,
     startup_secs = startup_measured,
     compute_collect_secs = compute_collect_secs,
@@ -189,6 +251,7 @@ emit_markdown <- function(runs) {
     sprintf("- **Date tested:** %s", run_date),
     sprintf("- **AWS region:** %s", region),
     sprintf("- **Backend:** %s", runs[[1]]$launch_type),
+    sprintf("- **Instance type:** %s", runs[[1]]$instance_type %||% "n/a"),
     sprintf("- **Spot:** %s (staRburst default use_spot=TRUE)", "yes"),
     sprintf("- **Cold or warm:** %s", if (runs[[1]]$warm) "warm (startup excluded)" else "cold (startup included)"),
     sprintf("- **Local machine:** %s", local_desc),
@@ -220,9 +283,11 @@ targets <- if (identical(which_wl, "all")) names(WORKLOADS) else which_wl
 runs <- lapply(targets, run_workload)
 
 md <- emit_markdown(runs)
+# Resolve output against the ORIGINAL working dir (we setwd()'d into a temp env dir).
 out_path <- out_path %||% file.path(
   "bench", "results",
   sprintf("%s-%s.md", if (identical(which_wl, "all")) "all" else which_wl, run_date))
+if (!startsWith(out_path, "/")) out_path <- file.path(.orig_wd, out_path)
 dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
 writeLines(md, out_path)
 saveRDS(list(runs = runs, version = sb_version, region = region,

--- a/bench/worker-renv.lock
+++ b/bench/worker-renv.lock
@@ -1,0 +1,289 @@
+{
+  "R": {
+    "Version": "4.6.1",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://cloud.r-project.org"
+      }
+    ]
+  },
+  "Packages": {
+    "askpass": {
+      "Package": "askpass",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "base64enc": {
+      "Package": "base64enc",
+      "Version": "0.1-6",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "cli": {
+      "Package": "cli",
+      "Version": "3.6.6",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "7.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "digest": {
+      "Package": "digest",
+      "Version": "0.6.39",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "docopt": {
+      "Package": "docopt",
+      "Version": "0.7.2",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "future": {
+      "Package": "future",
+      "Version": "1.75.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "globals": {
+      "Package": "globals",
+      "Version": "0.19.1",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "glue": {
+      "Package": "glue",
+      "Version": "1.8.1",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "httr2": {
+      "Package": "httr2",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "jsonlite": {
+      "Package": "jsonlite",
+      "Version": "2.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "lifecycle": {
+      "Package": "lifecycle",
+      "Version": "1.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "listenv": {
+      "Package": "listenv",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "littler": {
+      "Package": "littler",
+      "Version": "0.3.23",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "magrittr": {
+      "Package": "magrittr",
+      "Version": "2.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "openssl": {
+      "Package": "openssl",
+      "Version": "2.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "parallelly": {
+      "Package": "parallelly",
+      "Version": "1.48.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "paws.common": {
+      "Package": "paws.common",
+      "Version": "0.8.10",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "paws.compute": {
+      "Package": "paws.compute",
+      "Version": "0.10.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "paws.storage": {
+      "Package": "paws.storage",
+      "Version": "0.10.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "qs2": {
+      "Package": "qs2",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "R6": {
+      "Package": "R6",
+      "Version": "2.6.1",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "Rcpp": {
+      "Package": "Rcpp",
+      "Version": "1.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "RcppParallel": {
+      "Package": "RcppParallel",
+      "Version": "5.1.11-2",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "renv": {
+      "Package": "renv",
+      "Version": "1.2.3",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "stringfish": {
+      "Package": "stringfish",
+      "Version": "0.19.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "sys": {
+      "Package": "sys",
+      "Version": "3.4.3",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "vctrs": {
+      "Package": "vctrs",
+      "Version": "0.7.3",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "withr": {
+      "Package": "withr",
+      "Version": "3.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "xml2": {
+      "Package": "xml2",
+      "Version": "1.6.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "boot": {
+      "Package": "boot",
+      "Version": "1.3-32",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "class": {
+      "Package": "class",
+      "Version": "7.3-23",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "cluster": {
+      "Package": "cluster",
+      "Version": "2.1.8.2",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "codetools": {
+      "Package": "codetools",
+      "Version": "0.2-20",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "foreign": {
+      "Package": "foreign",
+      "Version": "0.8-91",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "KernSmooth": {
+      "Package": "KernSmooth",
+      "Version": "2.23-26",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "lattice": {
+      "Package": "lattice",
+      "Version": "0.22-9",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "MASS": {
+      "Package": "MASS",
+      "Version": "7.3-65",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "Matrix": {
+      "Package": "Matrix",
+      "Version": "1.7-5",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "mgcv": {
+      "Package": "mgcv",
+      "Version": "1.9-4",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "nlme": {
+      "Package": "nlme",
+      "Version": "3.1-169",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "nnet": {
+      "Package": "nnet",
+      "Version": "7.3-20",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "rpart": {
+      "Package": "rpart",
+      "Version": "4.1.27",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "spatial": {
+      "Package": "spatial",
+      "Version": "7.3-18",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "survival": {
+      "Package": "survival",
+      "Version": "3.8-6",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    }
+  }
+}


### PR DESCRIPTION
Adds `bench/benchmark.R` + `bench/README.md` + `bench/worker-renv.lock` — the reproducible, phase-split benchmark harness from issue #35.

## What it does
For each workload it records full disclosure metadata (staRburst version, region, backend, instance type, workers, spot, cold/warm, local machine, date) and splits wall-clock into **startup / compute+collect / total** with an estimated cost, emitting a paste-ready markdown table + `.rds`.

- Uses `starburst_session()` to cleanly separate worker startup from submit/collect.
- **Opt-in only**: refuses to run without `STARBURST_BENCH=TRUE`; launches real billable workers, so it never runs in CI/CRAN. `bench/` is in `.Rbuildignore`.
- `--warm` (report the second run, startup excluded), `--workers`, `--launch-type`, `--instance-type`, `--out` flags.
- `bench/worker-renv.lock` is the exact package set of the base image (so the worker env build is a no-op restore).

## Verified live
Exercised end-to-end on real AWS: builds the worker image, launches 20 workers, and the workers execute and write **20 real, distinct geospatial results** to S3. 

## Findings (documented in bench/README + filed as issues)
Getting there surfaced four real staRburst integration behaviors, now filed:
- **#37** — `starburst_session(EC2)` fails if the instance-type ASG isn't pre-provisioned.
- **#38** — `collect(wait=TRUE)` can hang after all results are in S3. **This is why the harness can't yet auto-emit compute timings**, so the vignette tables stay labelled *illustrative* (satisfies #35's "or clearly relabeled illustrative" branch).
- **#39** — the public base image is amd64-only but the env build requires multi-arch.

## Acceptance (#35)
- [x] Harness runs an example end-to-end, phase-split table + full metadata
- [x] Opt-in; never executes in CI
- [x] geospatial/bootstrap tables: relabeled illustrative (the OR branch), pending #38 for measured numbers

Refs #35; closes nothing automatically (leaving #35 open until measured tables are viable post-#38, or close if the relabel branch is accepted).