### PR TITLE
Fix collect(wait=TRUE) hang on live bootstrap tasks (closes #38)

### DIFF
--- a/R/session-api.R
+++ b/R/session-api.R
@@ -478,8 +478,13 @@ collect_session_results <- function(session, wait, timeout) {
       break
     }
 
-    # Check if all tasks are completed
-    all_completed <- all(vapply(statuses, function(s) {
+    # Check if all *user* tasks are completed. Bootstrap tasks
+    # (bootstrap-session-...) are the long-lived workers polling the queue; they
+    # stay "claimed"/"running" for the life of the session, so they must be
+    # excluded here — otherwise all_completed is never TRUE and a wait=TRUE
+    # collect hangs until the timeout even though every real result has landed.
+    user_statuses <- statuses[!grepl("^bootstrap-", names(statuses))]
+    all_completed <- length(user_statuses) > 0 && all(vapply(user_statuses, function(s) {
       s$state %in% c("completed", "failed")
     }, FUN.VALUE = logical(1)))
 

--- a/tests/testthat/test-detached-sessions.R
+++ b/tests/testthat/test-detached-sessions.R
@@ -235,3 +235,35 @@ test_that("plan guard prevents detached mode misuse", {
     "Detached mode cannot be used with plan"
   )
 })
+
+test_that("collect(wait=TRUE) returns when user tasks finish despite live bootstrap tasks", {
+  # Regression for #38: the all_completed check must ignore bootstrap-* tasks,
+  # which stay "claimed"/"running" for the session's life. Otherwise wait=TRUE
+  # hangs until timeout even though every real result has landed in S3.
+  skip_if_not_installed("mockery")
+
+  statuses <- list(
+    "bootstrap-session-x-1" = list(state = "claimed"),
+    "bootstrap-session-x-2" = list(state = "running"),
+    "task-aaa" = list(state = "completed"),
+    "task-bbb" = list(state = "completed")
+  )
+
+  mockery::stub(collect_session_results, "list_task_statuses", function(...) statuses)
+  mockery::stub(collect_session_results, "get_s3_client", function(...) {
+    list(download_file = function(Bucket, Key, Filename) {
+      qs2::qs_save(list(error = FALSE, value = 42), Filename)
+    })
+  })
+
+  session <- list(backend = list(session_id = "session-x", region = "us-east-1",
+                                 bucket = "b"))
+
+  # Must return quickly (well under the timeout) with both user results, not hang.
+  start <- Sys.time()
+  res <- collect_session_results(session, wait = TRUE, timeout = 30)
+  elapsed <- as.numeric(difftime(Sys.time(), start, units = "secs"))
+
+  expect_named(res, c("task-aaa", "task-bbb"), ignore.order = TRUE)
+  expect_lt(elapsed, 10)  # returned promptly, did not spin to timeout
+})


### PR DESCRIPTION
## The bug (#38)
`session$collect(wait = TRUE)` hangs until its timeout even after every task result has landed in S3.

## Root cause
`collect_session_results()`'s "all completed?" check counted **all** task statuses, including the `bootstrap-session-*` tasks. Those are the long-lived workers that poll the queue for the life of the session — they sit in state `claimed`/`running` and never reach `completed`. So `all_completed` was never `TRUE` and the loop spun to the timeout, even though the result-collection loop right above it *already* skips bootstrap tasks (as does `get_session_status()`).

Confirmed against the last live run: 20 real results present in `s3://.../results/`, bootstrap task state = `claimed`, collect never returned.

## Fix
Exclude `bootstrap-*` from the `all_completed` check (one-liner mirroring the existing skip), plus a guard so an empty user-task set doesn't early-return before any real task exists.

## Test
Added a mockery-based regression test (no AWS): completed user tasks + perpetually-`claimed` bootstrap tasks → `collect(wait=TRUE)` returns promptly with both results. **Verified it FAILS against the pre-fix code** (spins to timeout) and passes after.

## Verification
`devtools::check()` → 0 errors / 0 warnings / 0 notes. Full test suite + doc-consistency pass.

## Impact
Unblocks the #35 benchmark harness from auto-emitting *measured* timing tables (it was stuck waiting on this collect). Closes #38.