### PR TITLE
Third-review remediation: every documented path works & matches runtime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # starburst 0.3.9 (development)
 
+## New features
+
+* **`starburst_setup()` now provisions the default EC2 capacity provider** (for
+  `c7g.xlarge`) so the default EC2 backend works out of the box — previously the
+  first `starburst_map()`/`plan(starburst)` run failed because no capacity provider
+  existed. It is created at `DesiredCapacity = 0` (no billable instances launch
+  during setup). Pass `setup_ec2 = FALSE` to skip (Fargate-only users). (#37)
+
+## Breaking changes
+
+* **Removed the `platform` argument from `starburst_map()` and
+  `starburst_cluster()`.** It was ignored (architecture is inferred from
+  `instance_type`: Graviton `*g.*` → ARM64, else x86_64), and its `"X86_64"`
+  default even contradicted the ARM64 `c7g.xlarge` default. Drop it from calls; the
+  backend picks the architecture from `instance_type`. (`platform` remains on
+  `starburst_estimate()`, where it is functional.)
+* **Renamed `starburst_config(max_cost_per_job=)` to `max_hourly_cost`.** The limit
+  was always enforced as an hourly *rate* (USD/hour), not a total-job cap; the new
+  name matches the behavior. Update any `starburst_config(max_cost_per_job = ...)`
+  calls to `max_hourly_cost = ...`.
+
 ## Bug fixes
 
 * **`starburst_map()` and `starburst_cluster()` now accept `launch_type`,
@@ -10,6 +31,10 @@
   switching the backend — contradicting the 0.3.7 migration note. Backend
   selection now works uniformly across `plan(starburst)`, `starburst_map()`,
   `starburst_cluster()`, and `starburst_session()`.
+* Fixed broken/misleading examples: the README detached-session example used a
+  nonexistent `detached = TRUE` argument; S3-read examples used base `read.csv()`/
+  `readRDS(url())` which cannot read `s3://`; and the API rate-limit example
+  aggregated to 10× its stated global limit across workers.
 
 ## Documentation
 

--- a/R/plan-starburst.R
+++ b/R/plan-starburst.R
@@ -155,11 +155,11 @@ plan.starburst <- function(strategy,
                     if (use_spot) " spot" else ""))
   }
 
-  # Check cost limits
-  if (!is.null(config$max_cost_per_job) && cost_est$per_hour > config$max_cost_per_job) {
+  # Check cost limits (max_hourly_cost is an hourly-RATE cap, USD/hour)
+  if (!is.null(config$max_hourly_cost) && cost_est$per_hour > config$max_hourly_cost) {
     stop(sprintf(
-      "Estimated cost ($%.2f/hr) exceeds limit ($%.2f/hr). Adjust with starburst_config(max_cost_per_job = ...)",
-      cost_est$per_hour, config$max_cost_per_job
+      "Estimated cost ($%.2f/hr) exceeds limit ($%.2f/hr). Adjust with starburst_config(max_hourly_cost = ...)",
+      cost_est$per_hour, config$max_hourly_cost
     ))
   }
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -286,10 +286,11 @@ config_path <- function() {
 #' to leave settings unchanged (it still returns the current config invisibly); pass
 #' one or more of the arguments below to update them.
 #'
-#' @param max_cost_per_job Maximum estimated cost (USD) for a single job. Jobs whose
-#'   estimate exceeds this error before launching. \code{NULL} leaves it unchanged.
-#' @param cost_alert_threshold Estimated cost (USD) at which a warning is emitted.
-#'   \code{NULL} leaves it unchanged.
+#' @param max_hourly_cost Maximum estimated **hourly** cost (USD/hour) for a job.
+#'   Jobs whose estimated hourly rate exceeds this error before launching. This is a
+#'   rate limit, not a total-job-cost cap. \code{NULL} leaves it unchanged.
+#' @param cost_alert_threshold Estimated **hourly** cost (USD/hour) at which a
+#'   warning is emitted. \code{NULL} leaves it unchanged.
 #' @param auto_cleanup_s3 Logical; automatically delete a job's S3 task/result
 #'   objects after completion. \code{NULL} leaves it unchanged.
 #' @param ... Additional user-settable keys merged into the config. Recognized keys:
@@ -316,9 +317,9 @@ config_path <- function() {
 #' @examples
 #' \donttest{
 #' if (starburst_is_configured()) {
-#'   # Update cost guardrails
+#'   # Update cost guardrails (both are hourly rates, USD/hour)
 #'   starburst_config(
-#'     max_cost_per_job = 10,
+#'     max_hourly_cost = 10,
 #'     cost_alert_threshold = 5
 #'   )
 #'
@@ -326,7 +327,7 @@ config_path <- function() {
 #'   cfg <- starburst_config()
 #' }
 #' }
-starburst_config <- function(max_cost_per_job = NULL,
+starburst_config <- function(max_hourly_cost = NULL,
                              cost_alert_threshold = NULL,
                              auto_cleanup_s3 = NULL,
                              ...) {
@@ -334,8 +335,8 @@ starburst_config <- function(max_cost_per_job = NULL,
   config <- get_starburst_config()
 
   # Update config
-  if (!is.null(max_cost_per_job)) {
-    config$max_cost_per_job <- max_cost_per_job
+  if (!is.null(max_hourly_cost)) {
+    config$max_hourly_cost <- max_hourly_cost
   }
 
   if (!is.null(cost_alert_threshold)) {

--- a/R/setup.R
+++ b/R/setup.R
@@ -16,6 +16,14 @@
 #'   check quotas without triggering the multi-minute Docker image build. The
 #'   image is then built lazily on first worker launch via
 #'   \code{ensure_environment()}. Useful for CI / connectivity checks.
+#' @param setup_ec2 Provision the EC2 capacity provider and Auto Scaling Group for
+#'   the default instance type during setup (default: TRUE). This is what makes the
+#'   default EC2 backend work out of the box — without it, the first
+#'   \code{starburst_map()}/\code{plan(starburst)} run on EC2 would fail because no
+#'   capacity provider exists. It creates infrastructure at \code{DesiredCapacity = 0}
+#'   (no billable instances are launched during setup). Set to FALSE if you only use
+#'   the Fargate backend, which needs no capacity provider. Provision additional
+#'   instance types later with \code{\link{starburst_setup_ec2}}.
 #'
 #' @return Invisibly returns the configuration list.
 #' @export
@@ -37,7 +45,8 @@
 #' }
 #' }
 starburst_setup <- function(region = "us-east-1", force = FALSE, use_public_base = TRUE,
-                            ecr_image_ttl_days = NULL, build_image = TRUE) {
+                            ecr_image_ttl_days = NULL, build_image = TRUE,
+                            setup_ec2 = TRUE) {
 
   cat_header("[Start] staRburst Setup\n")
 
@@ -51,8 +60,12 @@ starburst_setup <- function(region = "us-east-1", force = FALSE, use_public_base
   cat_info("\nThis will configure AWS resources for staRburst:\n")
   cat_info("  * S3 bucket for data transfer\n")
   cat_info("  * ECR repository for Docker images\n")
-  cat_info("  * ECS cluster for Fargate tasks\n")
+  cat_info("  * ECS cluster (used by both EC2 and Fargate backends)\n")
   cat_info("  * VPC resources (subnets, security groups)\n")
+  if (setup_ec2) {
+    cat_info("  * EC2 capacity provider + Auto Scaling Group for the default\n")
+    cat_info("    instance type (so the default EC2 backend works immediately)\n")
+  }
 
   if (interactive()) {
     response <- readline("\nContinue? [y/n]: ")
@@ -128,6 +141,23 @@ starburst_setup <- function(region = "us-east-1", force = FALSE, use_public_base
   )
 
   save_config(config)
+
+  # Provision the default EC2 capacity provider + ASG so the default EC2 backend
+  # works out of the box. Without this, the first EC2 run fails: start_warm_pool()
+  # scales a named ASG that only setup_ec2_capacity_provider() creates. This makes
+  # infrastructure at DesiredCapacity = 0 — no billable instances launched here.
+  if (setup_ec2) {
+    cat_info("\n[EC2] Provisioning default EC2 capacity provider (c7g.xlarge)...\n")
+    cat_info("   * Creates a Launch Template + Auto Scaling Group at 0 instances\n")
+    cat_info("   * No instances launch until you run a job (no cost from setup)\n")
+    tryCatch({
+      starburst_setup_ec2(region = region, instance_types = "c7g.xlarge",
+                          force = TRUE)
+    }, error = function(e) {
+      cat_warn(sprintf("[!] EC2 capacity provisioning failed: %s\n", e$message))
+      cat_warn("    Run starburst_setup_ec2() manually, or use the Fargate backend.\n")
+    })
+  }
 
   # Check quotas proactively
   cat_info("\n[Status] Checking Fargate quotas...\n")

--- a/R/starburst-map.R
+++ b/R/starburst-map.R
@@ -8,12 +8,13 @@
 #' @param workers Number of parallel workers (default: 10)
 #' @param cpu CPU units per worker (1, 2, 4, 8, or 16)
 #' @param memory Memory per worker (e.g., 8GB)
-#' @param platform CPU architecture (X86_64 or ARM64)
 #' @param region AWS region
 #' @param timeout Maximum runtime in seconds per task
 #' @param launch_type Compute backend: "EC2" (default) or "FARGATE"
 #' @param instance_type EC2 instance type when \code{launch_type = "EC2"}
-#'   (default: "c7g.xlarge")
+#'   (default: "c7g.xlarge"). The worker CPU architecture follows the instance
+#'   type — Graviton types (e.g. \code{c7g.*}) run ARM64, Intel/AMD types
+#'   (e.g. \code{c7i.*}) run x86_64 — so there is no separate platform argument.
 #' @param use_spot Use EC2 Spot instances for cost savings (default: TRUE)
 #' @param .progress Show progress bar (default: TRUE)
 #' @param ... Additional arguments passed to .f
@@ -42,7 +43,7 @@
 #' }
 #' }
 starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
-                          platform = "X86_64", region = NULL, timeout = 3600,
+                          region = NULL, timeout = 3600,
                           launch_type = "EC2", instance_type = "c7g.xlarge",
                           use_spot = TRUE, .progress = TRUE, ...) {
 
@@ -50,7 +51,6 @@ starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
   validate_workers(workers)
   validate_cpu(cpu)
   validate_memory(memory)
-  validate_platform(platform)
 
   # Get configuration
   config <- get_starburst_config()
@@ -75,7 +75,6 @@ starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
     workers = workers,
     cpu = cpu,
     memory = memory,
-    platform = platform,
     region = region,
     timeout = timeout,
     launch_type = launch_type,
@@ -185,12 +184,13 @@ starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
 #' @param workers Number of parallel workers
 #' @param cpu CPU units per worker
 #' @param memory Memory per worker
-#' @param platform CPU architecture (X86_64 or ARM64)
 #' @param region AWS region
 #' @param timeout Maximum runtime in seconds
 #' @param launch_type Compute backend: "EC2" (default) or "FARGATE"
 #' @param instance_type EC2 instance type when \code{launch_type = "EC2"}
-#'   (default: "c7g.xlarge")
+#'   (default: "c7g.xlarge"). Worker CPU architecture follows the instance type
+#'   (Graviton \code{*g.*} = ARM64, Intel/AMD = x86_64); there is no separate
+#'   platform argument.
 #' @param use_spot Use EC2 Spot instances for cost savings (default: TRUE)
 #'
 #' @return A starburst_cluster object
@@ -207,7 +207,7 @@ starburst_map <- function(.x, .f, workers = 10, cpu = 4, memory = "8GB",
 #' }
 #' }
 starburst_cluster <- function(workers = 10, cpu = 4, memory = "8GB",
-                              platform = "X86_64", region = NULL, timeout = 3600,
+                              region = NULL, timeout = 3600,
                               launch_type = "EC2", instance_type = "c7g.xlarge",
                               use_spot = TRUE) {
 
@@ -221,7 +221,6 @@ starburst_cluster <- function(workers = 10, cpu = 4, memory = "8GB",
     workers = workers,
     cpu = cpu,
     memory = memory,
-    platform = platform,
     region = region,
     timeout = timeout,
     launch_type = launch_type,

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,13 +39,20 @@ staRburst lets you run parallel R code on AWS with zero infrastructure managemen
 
 ## Installation
 
-```r
-install.packages("starburst")
-```
+> **Note on versions.** This documentation describes the **development version,
+> 0.3.9**. The current CRAN release is **0.3.8**, which does **not** include some
+> APIs documented here (notably backend arguments — `launch_type`/`instance_type`/
+> `use_spot` — on `starburst_map()` and `starburst_cluster()`). To use the APIs as
+> documented, install from GitHub.
 
-Development version from GitHub:
+Development version (0.3.9 — matches this documentation):
 ```r
 remotes::install_github("scttfrdmn/starburst")
+```
+
+Latest CRAN release (0.3.8):
+```r
+install.packages("starburst")
 ```
 
 ## Quick Start
@@ -57,18 +64,19 @@ library(starburst)
 # +5-10 min once)
 starburst_setup()
 
-# Run parallel computation on AWS
+# Run parallel computation on AWS (each task should be real work — seconds+ —
+# so it's worth shipping; batch tiny items first). Console output is illustrative:
 results <- starburst_map(
-  1:1000,
+  inputs,                       # e.g. a list of scenarios / parameter sets
   function(x) expensive_computation(x),
   workers = 50
 )
 #> [Starting] Starting starburst cluster with 50 workers
-#> [Status] Processing 1000 items with 50 workers
-#> [Starting] Submitting 1000 tasks...
-#> [Wait] Progress: 1000/1000 (192.0s)
-#> [OK] Completed in 192.0 seconds
-#> [Cost] Estimated cost: $0.15
+#> [Status] Processing 200 items with 50 workers
+#> [Starting] Submitting 200 tasks...
+#> [Wait] Progress: 200/200
+#> [OK] Completed
+#> [Cost] Estimated cost: (printed per run)
 ```
 
 ## Example: Monte Carlo Simulation
@@ -88,18 +96,16 @@ simulate_portfolio <- function(seed) {
   )
 }
 
-# Run 10,000 simulations on 100 AWS workers
+# Each simulation is tiny (sub-millisecond), so BATCH them: 100 tasks of 100
+# simulations each, not 10,000 one-simulation tasks. (Thousands of tiny tasks are
+# an anti-pattern — see the "Workload Shapes" guide for measured numbers.)
+batches <- split(1:10000, ceiling(seq_along(1:10000) / 100))
 results <- starburst_map(
-  1:10000,
-  simulate_portfolio,
-  workers = 100
+  batches,
+  function(seeds) lapply(seeds, simulate_portfolio),
+  workers = 50
 )
-#> [Starting] Starting starburst cluster with 100 workers
-#> [Status] Processing 10000 items with 100 workers
-#> [Starting] Submitting 10000 tasks...
-#> [Wait] Progress: 10000/10000 (186.0s)
-#> [OK] Completed in 186.0 seconds
-#> [Cost] Estimated cost: $0.29
+results <- unlist(results, recursive = FALSE)  # flatten to 10,000 results
 
 # Extract results
 final_values <- sapply(results, function(x) x$final_value)
@@ -108,11 +114,12 @@ sharpe_ratios <- sapply(results, function(x) x$sharpe_ratio)
 # Summary
 mean(final_values)    # Average portfolio outcome
 quantile(final_values, c(0.05, 0.95))  # Risk range
-
-# Comparison:
-# Local (single core): ~4 hours
-# Cloud (100 workers): 3 minutes, $0.29
 ```
+
+> For real, measured performance (when the cloud wins, when it loses, and how to
+> size tasks/workers), see the
+> [Workload Shapes](https://starburst.ing/articles/workload-shapes.html) and
+> [Performance](https://starburst.ing/articles/performance.html) guides.
 
 ## Advanced Usage
 
@@ -157,24 +164,24 @@ results <- starburst_map(
 Run long jobs and disconnect - results persist in S3:
 
 ```{r}
-# Start detached session
-session <- starburst_session(workers = 50, detached = TRUE)
+# Start a detached session (EC2 + Spot by default)
+session <- starburst_session(workers = 50)
 
-# Submit work and get session ID
-session$submit(quote({
-  results <- starburst_map(huge_dataset, expensive_function)
-  saveRDS(results, "results.rds")
-}))
+# Fan work out by submitting one task per input
+task_ids <- lapply(inputs, function(input) {
+  session$submit(quote(expensive_function(input)),
+                 globals = list(input = input))
+})
 session_id <- session$session_id
 
-# Disconnect - job continues running
-# Later (hours/days), reconnect:
+# Disconnect - job continues running.
+# Later (hours/days), reconnect from a fresh R session:
 session <- starburst_session_attach(session_id)
-status <- session$status()  # Check progress
-results <- session$collect()  # Get results
+status  <- session$status()          # Check progress
+results <- session$collect(wait = TRUE)  # Collect results (in submission order)
 
 # Cleanup when done
-session$cleanup(force = TRUE)
+session$cleanup()
 ```
 
 ## How It Works
@@ -195,10 +202,10 @@ session$cleanup(force = TRUE)
 ## Cost Management
 
 ```{r}
-# Set cost limits
+# Set an hourly cost ceiling (USD/hour)
 starburst_config(
-  max_cost_per_job = 10,      # Hard limit
-  cost_alert_threshold = 5     # Warning at $5
+  max_hourly_cost = 10,       # Jobs estimated over $10/hour won't start
+  cost_alert_threshold = 5     # Warn at $5/hour
 )
 
 # Costs shown transparently
@@ -235,9 +242,8 @@ Your work still completes, just with fewer workers. You can request quota increa
 
 ```r
 starburst_config(
-  region = "us-east-1",
-  max_cost_per_job = 10,
-  cost_alert_threshold = 5
+  max_hourly_cost = 10,        # USD/hour rate ceiling
+  cost_alert_threshold = 5     # USD/hour warning
 )
 ```
 
@@ -277,16 +283,18 @@ For detailed setup instructions, see the [Getting Started](https://starburst.ing
 
 ## Roadmap
 
-### v0.3.8 (Current - on CRAN)
+### v0.3.9 (development — this documentation)
+- ✅ Backend arguments (`launch_type`/`instance_type`/`use_spot`) on `starburst_map()`/`starburst_cluster()`
+- ✅ One-step EC2 setup (`starburst_setup()` provisions the default capacity provider)
+- ✅ Measured performance/workload-shape guides
+
+### v0.3.8 (current CRAN release)
 - ✅ Direct API (`starburst_map`, `starburst_cluster`)
-- ✅ AWS Fargate integration
-- ✅ EC2 backend support with spot instances
+- ✅ EC2 backend (default, with spot instances) + Fargate (serverless alternative)
 - ✅ Detached session mode for long-running jobs
 - ✅ Automatic environment management
 - ✅ Cost tracking and quota handling
-- ✅ Full `future` backend integration
-- ✅ Support for `future.apply`, `furrr`, `targets`
-- ✅ Comprehensive AWS integration testing
+- ✅ Full `future` backend integration (`future.apply`, `furrr`, `targets`)
 - ✅ Security hardening (safe command execution, worker limits)
 - ✅ Published on CRAN (0 errors, 0 warnings, 0 notes)
 
@@ -313,7 +321,7 @@ Copyright 2026 Scott Friedman
   title = {staRburst: Seamless AWS Cloud Bursting for R},
   author = {Scott Friedman},
   year = {2026},
-  version = {0.3.8},
+  version = {0.3.9},
   url = {https://starburst.ing},
   license = {Apache-2.0}
 }

--- a/README.md
+++ b/README.md
@@ -37,14 +37,23 @@ and Fargate (serverless) backends.
 
 ## Installation
 
-``` r
-install.packages("starburst")
-```
+> **Note on versions.** This documentation describes the **development
+> version, 0.3.9**. The current CRAN release is **0.3.8**, which does
+> **not** include some APIs documented here (notably backend arguments —
+> `launch_type`/`instance_type`/ `use_spot` — on `starburst_map()` and
+> `starburst_cluster()`). To use the APIs as documented, install from
+> GitHub.
 
-Development version from GitHub:
+Development version (0.3.9 — matches this documentation):
 
 ``` r
 remotes::install_github("scttfrdmn/starburst")
+```
+
+Latest CRAN release (0.3.8):
+
+``` r
+install.packages("starburst")
 ```
 
 ## Quick Start
@@ -56,18 +65,19 @@ library(starburst)
 # +5-10 min once)
 starburst_setup()
 
-# Run parallel computation on AWS
+# Run parallel computation on AWS (each task should be real work — seconds+ —
+# so it's worth shipping; batch tiny items first). Console output is illustrative:
 results <- starburst_map(
-  1:1000,
+  inputs,                       # e.g. a list of scenarios / parameter sets
   function(x) expensive_computation(x),
   workers = 50
 )
 #> [Starting] Starting starburst cluster with 50 workers
-#> [Status] Processing 1000 items with 50 workers
-#> [Starting] Submitting 1000 tasks...
-#> [Wait] Progress: 1000/1000 (192.0s)
-#> [OK] Completed in 192.0 seconds
-#> [Cost] Estimated cost: $0.15
+#> [Status] Processing 200 items with 50 workers
+#> [Starting] Submitting 200 tasks...
+#> [Wait] Progress: 200/200
+#> [OK] Completed
+#> [Cost] Estimated cost: (printed per run)
 ```
 
 ## Example: Monte Carlo Simulation
@@ -87,18 +97,16 @@ simulate_portfolio <- function(seed) {
   )
 }
 
-# Run 10,000 simulations on 100 AWS workers
+# Each simulation is tiny (sub-millisecond), so BATCH them: 100 tasks of 100
+# simulations each, not 10,000 one-simulation tasks. (Thousands of tiny tasks are
+# an anti-pattern — see the "Workload Shapes" guide for measured numbers.)
+batches <- split(1:10000, ceiling(seq_along(1:10000) / 100))
 results <- starburst_map(
-  1:10000,
-  simulate_portfolio,
-  workers = 100
+  batches,
+  function(seeds) lapply(seeds, simulate_portfolio),
+  workers = 50
 )
-#> [Starting] Starting starburst cluster with 100 workers
-#> [Status] Processing 10000 items with 100 workers
-#> [Starting] Submitting 10000 tasks...
-#> [Wait] Progress: 10000/10000 (186.0s)
-#> [OK] Completed in 186.0 seconds
-#> [Cost] Estimated cost: $0.29
+results <- unlist(results, recursive = FALSE)  # flatten to 10,000 results
 
 # Extract results
 final_values <- sapply(results, function(x) x$final_value)
@@ -107,11 +115,12 @@ sharpe_ratios <- sapply(results, function(x) x$sharpe_ratio)
 # Summary
 mean(final_values)    # Average portfolio outcome
 quantile(final_values, c(0.05, 0.95))  # Risk range
-
-# Comparison:
-# Local (single core): ~4 hours
-# Cloud (100 workers): 3 minutes, $0.29
 ```
+
+> For real, measured performance (when the cloud wins, when it loses,
+> and how to size tasks/workers), see the [Workload
+> Shapes](https://starburst.ing/articles/workload-shapes.html) and
+> [Performance](https://starburst.ing/articles/performance.html) guides.
 
 ## Advanced Usage
 
@@ -156,24 +165,24 @@ results <- starburst_map(
 Run long jobs and disconnect - results persist in S3:
 
 ``` r
-# Start detached session
-session <- starburst_session(workers = 50, detached = TRUE)
+# Start a detached session (EC2 + Spot by default)
+session <- starburst_session(workers = 50)
 
-# Submit work and get session ID
-session$submit(quote({
-  results <- starburst_map(huge_dataset, expensive_function)
-  saveRDS(results, "results.rds")
-}))
+# Fan work out by submitting one task per input
+task_ids <- lapply(inputs, function(input) {
+  session$submit(quote(expensive_function(input)),
+                 globals = list(input = input))
+})
 session_id <- session$session_id
 
-# Disconnect - job continues running
-# Later (hours/days), reconnect:
+# Disconnect - job continues running.
+# Later (hours/days), reconnect from a fresh R session:
 session <- starburst_session_attach(session_id)
-status <- session$status()  # Check progress
-results <- session$collect()  # Get results
+status  <- session$status()          # Check progress
+results <- session$collect(wait = TRUE)  # Collect results (in submission order)
 
 # Cleanup when done
-session$cleanup(force = TRUE)
+session$cleanup()
 ```
 
 ## How It Works
@@ -199,10 +208,10 @@ session$cleanup(force = TRUE)
 ## Cost Management
 
 ``` r
-# Set cost limits
+# Set an hourly cost ceiling (USD/hour)
 starburst_config(
-  max_cost_per_job = 10,      # Hard limit
-  cost_alert_threshold = 5     # Warning at $5
+  max_hourly_cost = 10,       # Jobs estimated over $10/hour won't start
+  cost_alert_threshold = 5     # Warn at $5/hour
 )
 
 # Costs shown transparently
@@ -241,9 +250,8 @@ quota increases through AWS Service Quotas.
 
 ``` r
 starburst_config(
-  region = "us-east-1",
-  max_cost_per_job = 10,
-  cost_alert_threshold = 5
+  max_hourly_cost = 10,        # USD/hour rate ceiling
+  cost_alert_threshold = 5     # USD/hour warning
 )
 ```
 
@@ -287,17 +295,24 @@ Started](https://starburst.ing/articles/getting-started.html) guide.
 
 ## Roadmap
 
-### v0.3.8 (Current - on CRAN)
+### v0.3.9 (development — this documentation)
+
+- ✅ Backend arguments (`launch_type`/`instance_type`/`use_spot`) on
+  `starburst_map()`/`starburst_cluster()`
+- ✅ One-step EC2 setup (`starburst_setup()` provisions the default
+  capacity provider)
+- ✅ Measured performance/workload-shape guides
+
+### v0.3.8 (current CRAN release)
 
 - ✅ Direct API (`starburst_map`, `starburst_cluster`)
-- ✅ AWS Fargate integration
-- ✅ EC2 backend support with spot instances
+- ✅ EC2 backend (default, with spot instances) + Fargate (serverless
+  alternative)
 - ✅ Detached session mode for long-running jobs
 - ✅ Automatic environment management
 - ✅ Cost tracking and quota handling
-- ✅ Full `future` backend integration
-- ✅ Support for `future.apply`, `furrr`, `targets`
-- ✅ Comprehensive AWS integration testing
+- ✅ Full `future` backend integration (`future.apply`, `furrr`,
+  `targets`)
 - ✅ Security hardening (safe command execution, worker limits)
 - ✅ Published on CRAN (0 errors, 0 warnings, 0 notes)
 
@@ -328,7 +343,7 @@ Copyright 2026 Scott Friedman
   title = {staRburst: Seamless AWS Cloud Bursting for R},
   author = {Scott Friedman},
   year = {2026},
-  version = {0.3.8},
+  version = {0.3.9},
   url = {https://starburst.ing},
   license = {Apache-2.0}
 }

--- a/man/starburst_cluster.Rd
+++ b/man/starburst_cluster.Rd
@@ -8,7 +8,6 @@ starburst_cluster(
   workers = 10,
   cpu = 4,
   memory = "8GB",
-  platform = "X86_64",
   region = NULL,
   timeout = 3600,
   launch_type = "EC2",
@@ -23,8 +22,6 @@ starburst_cluster(
 
 \item{memory}{Memory per worker}
 
-\item{platform}{CPU architecture (X86_64 or ARM64)}
-
 \item{region}{AWS region}
 
 \item{timeout}{Maximum runtime in seconds}
@@ -32,7 +29,9 @@ starburst_cluster(
 \item{launch_type}{Compute backend: "EC2" (default) or "FARGATE"}
 
 \item{instance_type}{EC2 instance type when \code{launch_type = "EC2"}
-(default: "c7g.xlarge")}
+(default: "c7g.xlarge"). Worker CPU architecture follows the instance type
+(Graviton \code{*g.*} = ARM64, Intel/AMD = x86_64); there is no separate
+platform argument.}
 
 \item{use_spot}{Use EC2 Spot instances for cost savings (default: TRUE)}
 }

--- a/man/starburst_config.Rd
+++ b/man/starburst_config.Rd
@@ -5,18 +5,19 @@
 \title{Configure staRburst options}
 \usage{
 starburst_config(
-  max_cost_per_job = NULL,
+  max_hourly_cost = NULL,
   cost_alert_threshold = NULL,
   auto_cleanup_s3 = NULL,
   ...
 )
 }
 \arguments{
-\item{max_cost_per_job}{Maximum estimated cost (USD) for a single job. Jobs whose
-estimate exceeds this error before launching. \code{NULL} leaves it unchanged.}
+\item{max_hourly_cost}{Maximum estimated **hourly** cost (USD/hour) for a job.
+Jobs whose estimated hourly rate exceeds this error before launching. This is a
+rate limit, not a total-job-cost cap. \code{NULL} leaves it unchanged.}
 
-\item{cost_alert_threshold}{Estimated cost (USD) at which a warning is emitted.
-\code{NULL} leaves it unchanged.}
+\item{cost_alert_threshold}{Estimated **hourly** cost (USD/hour) at which a
+warning is emitted. \code{NULL} leaves it unchanged.}
 
 \item{auto_cleanup_s3}{Logical; automatically delete a job's S3 task/result
 objects after completion. \code{NULL} leaves it unchanged.}
@@ -48,9 +49,9 @@ to be set by hand: \code{region}, \code{bucket}, \code{cluster},
 \examples{
 \donttest{
 if (starburst_is_configured()) {
-  # Update cost guardrails
+  # Update cost guardrails (both are hourly rates, USD/hour)
   starburst_config(
-    max_cost_per_job = 10,
+    max_hourly_cost = 10,
     cost_alert_threshold = 5
   )
 

--- a/man/starburst_map.Rd
+++ b/man/starburst_map.Rd
@@ -10,7 +10,6 @@ starburst_map(
   workers = 10,
   cpu = 4,
   memory = "8GB",
-  platform = "X86_64",
   region = NULL,
   timeout = 3600,
   launch_type = "EC2",
@@ -31,8 +30,6 @@ starburst_map(
 
 \item{memory}{Memory per worker (e.g., 8GB)}
 
-\item{platform}{CPU architecture (X86_64 or ARM64)}
-
 \item{region}{AWS region}
 
 \item{timeout}{Maximum runtime in seconds per task}
@@ -40,7 +37,9 @@ starburst_map(
 \item{launch_type}{Compute backend: "EC2" (default) or "FARGATE"}
 
 \item{instance_type}{EC2 instance type when \code{launch_type = "EC2"}
-(default: "c7g.xlarge")}
+(default: "c7g.xlarge"). The worker CPU architecture follows the instance
+type — Graviton types (e.g. \code{c7g.*}) run ARM64, Intel/AMD types
+(e.g. \code{c7i.*}) run x86_64 — so there is no separate platform argument.}
 
 \item{use_spot}{Use EC2 Spot instances for cost savings (default: TRUE)}
 

--- a/man/starburst_setup.Rd
+++ b/man/starburst_setup.Rd
@@ -9,7 +9,8 @@ starburst_setup(
   force = FALSE,
   use_public_base = TRUE,
   ecr_image_ttl_days = NULL,
-  build_image = TRUE
+  build_image = TRUE,
+  setup_ec2 = TRUE
 )
 }
 \arguments{
@@ -31,6 +32,15 @@ Set to FALSE to provision AWS resources (S3/ECR/ECS/VPC), write config, and
 check quotas without triggering the multi-minute Docker image build. The
 image is then built lazily on first worker launch via
 \code{ensure_environment()}. Useful for CI / connectivity checks.}
+
+\item{setup_ec2}{Provision the EC2 capacity provider and Auto Scaling Group for
+the default instance type during setup (default: TRUE). This is what makes the
+default EC2 backend work out of the box — without it, the first
+\code{starburst_map()}/\code{plan(starburst)} run on EC2 would fail because no
+capacity provider exists. It creates infrastructure at \code{DesiredCapacity = 0}
+(no billable instances are launched during setup). Set to FALSE if you only use
+the Fargate backend, which needs no capacity provider. Provision additional
+instance types later with \code{\link{starburst_setup_ec2}}.}
 }
 \value{
 Invisibly returns the configuration list.

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1,0 +1,54 @@
+test_that("starburst_setup provisions default EC2 capacity by default", {
+  skip_if_not_installed("mockery")
+
+  # Stub every AWS collaborator so no network/credentials are touched.
+  mockery::stub(starburst_setup, "check_aws_credentials", function() TRUE)
+  mockery::stub(starburst_setup, "create_starburst_bucket", function(...) "starburst-test-bucket")
+  mockery::stub(starburst_setup, "create_ecr_repository",
+                function(...) list(repositoryUri = "acct.dkr.ecr/starburst-worker"))
+  mockery::stub(starburst_setup, "create_ecs_cluster",
+                function(...) list(clusterName = "starburst-cluster"))
+  mockery::stub(starburst_setup, "setup_vpc_resources",
+                function(...) list(vpc_id = "vpc-1", subnets = c("s-1"),
+                                   security_groups = c("sg-1")))
+  mockery::stub(starburst_setup, "get_aws_account_id", function() "123456789012")
+  mockery::stub(starburst_setup, "save_config", function(...) invisible(TRUE))
+  mockery::stub(starburst_setup, "check_fargate_quota",
+                function(...) list(limit = 1000, increase_pending = FALSE))
+  mockery::stub(starburst_setup, "build_initial_environment", function(...) "hash")
+
+  ec2_mock <- mockery::mock(invisible(TRUE))
+  mockery::stub(starburst_setup, "starburst_setup_ec2", ec2_mock)
+
+  # setup_ec2 = TRUE (default): starburst_setup_ec2 must be called once, for the
+  # default instance type, so the default EC2 backend works out of the box.
+  starburst_setup(region = "us-east-1", force = TRUE, build_image = FALSE)
+  mockery::expect_called(ec2_mock, 1)
+  args <- mockery::mock_args(ec2_mock)[[1]]
+  expect_true("c7g.xlarge" %in% unlist(args))
+})
+
+test_that("starburst_setup(setup_ec2 = FALSE) skips EC2 provisioning", {
+  skip_if_not_installed("mockery")
+
+  mockery::stub(starburst_setup, "check_aws_credentials", function() TRUE)
+  mockery::stub(starburst_setup, "create_starburst_bucket", function(...) "b")
+  mockery::stub(starburst_setup, "create_ecr_repository",
+                function(...) list(repositoryUri = "uri"))
+  mockery::stub(starburst_setup, "create_ecs_cluster",
+                function(...) list(clusterName = "starburst-cluster"))
+  mockery::stub(starburst_setup, "setup_vpc_resources",
+                function(...) list(vpc_id = "vpc-1", subnets = c("s-1"),
+                                   security_groups = c("sg-1")))
+  mockery::stub(starburst_setup, "get_aws_account_id", function() "123456789012")
+  mockery::stub(starburst_setup, "save_config", function(...) invisible(TRUE))
+  mockery::stub(starburst_setup, "check_fargate_quota",
+                function(...) list(limit = 1000, increase_pending = FALSE))
+
+  ec2_mock <- mockery::mock(invisible(TRUE))
+  mockery::stub(starburst_setup, "starburst_setup_ec2", ec2_mock)
+
+  starburst_setup(region = "us-east-1", force = TRUE, build_image = FALSE,
+                  setup_ec2 = FALSE)
+  mockery::expect_called(ec2_mock, 0)
+})

--- a/tools/check-docs.R
+++ b/tools/check-docs.R
@@ -36,7 +36,11 @@ man_files <- list.files(file.path(pkg_root, "man"), pattern = "\\.Rd$", full.nam
 # ---- 1. Dead / banned symbols -------------------------------------------------
 # Symbols that no longer exist and must never reappear in code or docs.
 banned <- c("future_starburst", "starburst_upload", "yourname/starburst",
-            "yourusername/starburst", "starburst_setup(bucket")
+            "yourusername/starburst", "starburst_setup(bucket",
+            # removed/renamed args that must not reappear in docs or code:
+            "detached = TRUE",   # starburst_session has no `detached` arg
+            "max_cost_per_job",  # renamed to max_hourly_cost
+            "readRDS(url(")      # base url() can't read s3:// — use an S3 client
 scan_targets <- c(vignettes, readme, r_files)
 for (f in scan_targets) {
   lines <- read_lines_safe(f)
@@ -128,6 +132,25 @@ for (f in man_files) {
     if (nchar(pd) && !identical(tolower(sig), tolower(pd))) {
       note(sprintf("[usage-vs-prose] %s: arg '%s' usage default '%s' != prose '(default: %s)'",
                    basename(f), nm, sig, pd))
+    }
+  }
+}
+
+# ---- 5. Naive big-count anti-pattern in examples -----------------------------
+# starburst_map(1:N, ...) with a large N is the "thousands of tiny tasks" trap the
+# guides warn against. Flag it in user-facing docs so examples model batching.
+anti_marker <- "DON'T|Bad:|❌|anti-pattern|don't do this"
+for (f in c(vignettes, readme)) {
+  lines <- read_lines_safe(f)
+  hits <- grep("starburst_map\\(\\s*1:([0-9]{4,})", lines)
+  for (h in hits) {
+    n <- as.integer(sub(".*starburst_map\\(\\s*1:([0-9]+).*", "\\1", lines[h]))
+    # Allow deliberately-labeled anti-pattern demos (a DON'T/Bad marker on this or
+    # the preceding two lines).
+    ctx <- paste(lines[max(1, h - 2):h], collapse = " ")
+    if (!is.na(n) && n >= 1000 && !grepl(anti_marker, ctx, ignore.case = TRUE)) {
+      note(sprintf("[naive-big-count] %s:%d starburst_map(1:%d, ...) — model batching or mark it as an anti-pattern (# DON'T / # Bad:)",
+                   basename(f), h, n))
     }
   }
 }

--- a/vignettes/example-api-calls.Rmd
+++ b/vignettes/example-api-calls.Rmd
@@ -287,29 +287,34 @@ cat(sprintf("Range: $%.2fB - $%.2fB\n",
 
 When working with real APIs:
 
-```{r rate-limiting, eval=FALSE}
-# Add jitter to respect rate limits
-fetch_with_rate_limit <- function(ticker, rate_limit = 100) {
-  # Add delay based on rate limit (calls per minute)
-  delay <- 60 / rate_limit + runif(1, 0, 0.1)
-  Sys.sleep(delay)
+Each worker throttles itself **independently**, so the *aggregate* rate is the
+per-worker rate times the number of workers. To respect a global API limit, give
+each worker its share: `per_worker_rate = global_limit / workers`.
 
+```{r rate-limiting, eval=FALSE}
+# per_worker_rate is calls/minute allowed to THIS worker
+fetch_with_rate_limit <- function(ticker, per_worker_rate) {
+  delay <- 60 / per_worker_rate + runif(1, 0, 0.1)
+  Sys.sleep(delay)
   fetch_company_data(ticker)
 }
 
-# Use with staRburst
+global_limit <- 100   # API allows 100 calls/minute total
+workers      <- 10
+per_worker   <- global_limit / workers   # 10 calls/min each
+
 results <- starburst_map(
   tickers,
-  function(x) fetch_with_rate_limit(x, rate_limit = 100),
-  workers = 10  # Adjust workers based on API rate limit
+  function(x) fetch_with_rate_limit(x, per_worker_rate = per_worker),
+  workers = workers
 )
 ```
 
 **Rate limit calculation**:
-- API limit: 100 calls/minute
-- Workers: 10
-- Max throughput: 1000 calls/minute (10 workers × 100 calls/min)
-- Adjust workers to stay under limit
+- API limit: 100 calls/minute (global)
+- Workers: 10 → each worker allowed 100 / 10 = 10 calls/minute
+- Aggregate throughput: 10 workers × 10 calls/min = **100 calls/minute** (at the limit)
+- Rule: `per_worker_rate = global_limit / workers` keeps the fleet under the cap
 
 ## Error Handling Best Practices
 

--- a/vignettes/example-monte-carlo.Rmd
+++ b/vignettes/example-monte-carlo.Rmd
@@ -113,37 +113,42 @@ cat(sprintf("Estimated time for 10,000: %.1f minutes\n",
             local_time * 100 / 60))
 ```
 
-**Typical output**:
+**Illustrative output** (depends on your machine):
 ```
-100 simulations completed in 2.3 seconds
-Estimated time for 10,000: 3.8 minutes
+100 simulations completed in ~2 seconds
+Estimated time for 10,000: ~a few minutes
 ```
-
-For 10,000 simulations locally: **~3.8 minutes**
 
 ## Cloud Execution with staRburst
 
-Run all 10,000 simulations on AWS:
+Each simulation is tiny (well under a millisecond), so this is a **batch-it**
+workload: submitting 10,000 one-simulation tasks would be dominated by per-task S3
+overhead (see the [Workload Shapes](https://starburst.ing/articles/workload-shapes.html)
+guide, which measures that anti-pattern at ~77 minutes). Instead, batch into ~100
+tasks of 100 simulations each:
 
 ```{r cloud, eval=FALSE}
-# Run 10,000 simulations on 50 workers
+# 100 tasks x 100 simulations = 10,000 simulations, batched
+batches <- split(1:10000, ceiling(seq_along(1:10000) / 100))
 results <- starburst_map(
-  1:10000,
-  simulate_portfolio,
+  batches,
+  function(seeds) lapply(seeds, simulate_portfolio),
   workers = 50,
   cpu = 2,
   memory = "4GB"
 )
+results <- unlist(results, recursive = FALSE)  # flatten to 10,000 results
 ```
 
-**Typical output**:
+**Illustrative output** (times/cost vary — see the Workload Shapes and Performance
+guides for measured numbers):
 ```
 [Starting] Starting starburst cluster with 50 workers
-[Status] Processing 10000 items with 50 workers
-[Starting] Submitting 10000 tasks...
-[Wait] Progress: 10000/10000 (72.4s)
-[OK] Completed in 72.4 seconds
-[Cost] Estimated cost: $0.06
+[Status] Processing 100 items with 50 workers
+[Starting] Submitting 100 tasks...
+[Wait] Progress: 100/100
+[OK] Completed
+[Cost] Estimated cost: (printed per run)
 ```
 
 ## Results Analysis
@@ -187,38 +192,26 @@ legend("topright",
        lwd = 2, lty = 2)
 ```
 
-**Typical output**:
+**Illustrative output** (values depend on the random draws):
 ```
 === Portfolio Simulation Results (10,000 scenarios) ===
 Mean final value: $1,102,450
 Median final value: $1,097,230
-
-Mean return: 10.24%
-Std dev of returns: 12.83%
-
+Mean return: 10.24%   Std dev: 12.83%
 Value at Risk (5%): $892,340
-Expected Shortfall (5%): $845,120
-
-Mean Sharpe Ratio: 0.82
-Mean Max Drawdown: 8.45%
-
 Probability of loss: 18.34%
 ```
 
-## Performance Comparison
+## Performance
 
-| Method | Workers | Time | Cost | Speedup |
-|--------|---------|------|------|---------|
-| Local | 1 | 3.8 min | $0 | 1x |
-| staRburst | 10 | 0.6 min | $0.03 | 6.3x |
-| staRburst | 25 | 0.3 min | $0.04 | 12.7x |
-| staRburst | 50 | 0.2 min | $0.06 | 19x |
-
-**Key Insights**:
-- Near-linear scaling up to 50 workers
-- Cost remains minimal ($0.06) even with 50 workers
-- Sweet spot: 25-50 workers for this workload
-- Total iteration time: <2 minutes from start to results
+Monte Carlo of tiny per-simulation tasks is a **batching** story, not a
+raw-fan-out story: batch to ~100 tasks (as above) and the run is dominated by real
+compute rather than per-task overhead. For **measured** cold/warm numbers — including
+how batching turns a ~77-minute naive run into minutes, and how to pick worker
+counts — see the
+[Workload Shapes](https://starburst.ing/articles/workload-shapes.html) and
+[Performance](https://starburst.ing/articles/performance.html) guides. We don't
+repeat hand-written speedup tables here; those guides are the single source of truth.
 
 ## When to Use This Pattern
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -37,6 +37,22 @@ first job with it. If you already have `future`/`furrr` code, skip to
 [Migrating existing future / furrr code](#migrating-existing-future-furrr-code);
 the two styles are equivalent and shown side by side there.
 
+### Which backend? EC2 (default) vs Fargate
+
+Every API above runs on one of two compute backends, chosen with `launch_type`:
+
+- **EC2 — the default and recommended choice.** Faster (no cold start), cheaper with
+  Spot (the default), and more flexible (any instance type, warm pools).
+  `starburst_setup()` provisions its capacity provider for you, so it works out of
+  the box.
+- **Fargate — an optional serverless alternative** (`launch_type = "FARGATE"`).
+  Fully managed and needs **no** `starburst_setup_ec2` / capacity provider, but has
+  cold-start latency and is bounded by your account's Fargate vCPU quota. Reach for
+  it if you specifically want task-based serverless execution.
+
+You don't have to choose up front — leave the default (EC2) and add
+`launch_type = "FARGATE"` later if you want to compare.
+
 ## How it works (the mental model)
 
 ```
@@ -288,6 +304,22 @@ all_variants <- do.call(rbind, lapply(results, `[[`, "variants"))
 
 ## Working with Data
 
+Base R's `read.csv()`/`readRDS()` cannot read `s3://` URLs — you need an S3 client
+on the worker. A small helper keeps the examples below concrete and copy-pasteable
+(the worker image already includes `paws.storage`):
+
+```{r}
+# Download an s3://bucket/key object to a temp file and read it on the worker.
+read_s3 <- function(s3_uri, reader = readRDS) {
+  m <- regmatches(s3_uri, regexec("^s3://([^/]+)/(.+)$", s3_uri))[[1]]
+  bucket <- m[2]; key <- m[3]
+  tmp <- tempfile()
+  obj <- paws.storage::s3()$get_object(Bucket = bucket, Key = key)
+  writeBin(obj$Body, tmp)
+  reader(tmp)
+}
+```
+
 ### Data Already in S3
 
 If your data is already in S3, workers can read it directly:
@@ -296,8 +328,8 @@ If your data is already in S3, workers can read it directly:
 plan(starburst, workers = 50)
 
 results <- future_map(file_list, function(file) {
-  # Workers read directly from S3
-  data <- read.csv(sprintf("s3://my-bucket/%s", file))
+  # Each worker pulls its file from S3 (read_s3 defined above)
+  data <- read_s3(sprintf("s3://my-bucket/%s", file), reader = read.csv)
   process(data)
 })
 ```
@@ -325,17 +357,18 @@ For very large objects, upload once to S3 yourself and have each worker read it
 from there, rather than serializing the object into every task:
 
 ```{r}
-# Upload once, using your preferred S3 client (e.g. paws.storage or the AWS CLI)
-large_data <- readRDS("huge_file.rds")
+# Upload once from your machine
+paws.storage::s3()$put_object(
+  Bucket = "my-bucket", Key = "large_data.rds",
+  Body = "huge_file.rds"
+)
 s3_path <- "s3://my-bucket/large_data.rds"
-# e.g. paws.storage::s3()$put_object(Bucket = "my-bucket",
-#        Key = "large_data.rds", Body = "huge_file.rds")
 
-# Workers read from S3 inside the task
+# Workers read from S3 inside the task (read_s3 helper defined above)
 plan(starburst, workers = 100)
 
 results <- future_map(1:1000, function(i) {
-  data <- readRDS(url(s3_path))  # or an S3 client of your choice
+  data <- read_s3(s3_path)   # readRDS by default
   process(data, i)
 })
 ```
@@ -535,12 +568,12 @@ results <- future_map(1:1000, function(i) process(big_data, i))
 Do:
 ```{r}
 # Upload once to S3
-s3_path <- "s3://bucket/big_data.csv"
-write.csv(big_data, s3_path)
+tmp <- tempfile(fileext = ".csv"); write.csv(big_data, tmp, row.names = FALSE)
+paws.storage::s3()$put_object(Bucket = "bucket", Key = "big_data.csv", Body = tmp)
 
-# Workers read from S3
+# Workers read from S3 (read_s3 helper from "Working with Data" above)
 results <- future_map(1:1000, function(i) {
-  data <- read.csv(s3_path)
+  data <- read_s3("s3://bucket/big_data.csv", reader = read.csv)
   process(data, i)
 })
 ```

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -353,10 +353,10 @@ plan(starburst, workers = 100, cpu = 4, memory = "8GB")
 ### Set Cost Limits
 
 ```{r}
-# Set maximum cost per job
+# Set an hourly cost ceiling (USD/hour) — jobs above this rate won't start
 starburst_config(
-  max_cost_per_job = 10,      # Don't start jobs that would cost >$10
-  cost_alert_threshold = 5     # Warn when approaching $5
+  max_hourly_cost = 10,       # Don't start jobs estimated over $10/hour
+  cost_alert_threshold = 5     # Warn at $5/hour
 )
 
 # Now jobs exceeding limit will error before starting
@@ -549,7 +549,7 @@ results <- future_map(1:1000, function(i) {
 
 ```{r}
 starburst_config(
-  max_cost_per_job = 50,           # Prevent accidents
+  max_hourly_cost = 50,            # Cap the hourly rate (USD/hour)
   cost_alert_threshold = 25        # Get warned early
 )
 ```


### PR DESCRIPTION
Addresses the third review (8.2/10). Its remaining issues were about **paths that don't match a working install/runtime** — every claim was verified against source (all confirmed) and fixed. User decisions: auto-provision EC2 in setup; keep Fargate (reposition as serverless alternative); dev banner (no release); remove `platform` + rename cost arg (clean, pre-1.0).

## The #1 issue — default EC2 now works one-step
`starburst_setup()` created S3/ECR/ECS/VPC but no capacity provider, so the golden path (`starburst_setup()` then `starburst_map()`) failed at first run (`start_warm_pool` calling `set_desired_capacity` on a nonexistent ASG). Now `starburst_setup()` provisions the default EC2 capacity provider (c7g.xlarge) at `DesiredCapacity=0` (no billable instances). `setup_ec2=FALSE` to skip. **Closes #37.** Tested (mocked).

## Misleading args fixed (clean, pre-1.0)
- **Removed `platform`** from `starburst_map()`/`starburst_cluster()` — it was ignored (arch follows `instance_type`) and its X86_64 default contradicted the ARM64 c7g default. Kept in `starburst_estimate()`, where it's functional.
- **`max_cost_per_job` renamed to `max_hourly_cost`** — always enforced as an hourly rate, not a total-job cap; the name now matches behavior.

## Broken/inconsistent examples
- README detached example: dropped nonexistent `detached=TRUE`; correct fan-out via repeated `session$submit()`.
- S3 reads: added a real `read_s3()` helper (paws.storage) — base `read.csv()`/`readRDS(url())` can't read `s3://`.
- api-calls rate-limit: per-worker = global/workers so the fleet stays under the cap.

## Timings — measured guides are the single source of truth
- Rewrote README + Monte Carlo 10k-task examples from the naive 1-per-point anti-pattern to batched, consistent with the measured guides; relabeled fabricated output "illustrative" and removed the contradictory 72.4s / 186s / "4 hours" numbers (the measured guide shows naive 10k about 77 min).
- Extended `tools/check-docs.R`: bans `detached=TRUE`/`max_cost_per_job`/`readRDS(url(`; flags `starburst_map(1:N)` with N>=1000 unless marked `# DON'T`/`# Bad:`. Verified it fails on reintroduction.

## CRAN vs dev + Fargate
- README: version banner (docs = 0.3.9-dev; CRAN = 0.3.8, lacks these APIs), GitHub-first install, roadmap split, citation to 0.3.9.
- getting-started: explicit backend guidance — EC2 default/recommended, Fargate optional serverless (no `setup_ec2` needed).

## Verification
`devtools::check()` -> 0/0/0; full suite 231 pass / 0 fail; `tools/check-docs.R` passes (and fails on reintroduced anti-patterns); grep sweep clean. NEWS 0.3.9 documents the breaking changes + migration.

Closes #37.
