### PR TITLE
Build public base images multi-arch (closes #39)

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up QEMU (for cross-arch arm64 builds)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -61,7 +64,7 @@ jobs:
             --build-arg R_VERSION=${{ matrix.r_version }} \
             --tag ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.REPOSITORY_NAME }}:r${{ matrix.r_version }} \
             --tag ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.REPOSITORY_NAME }}:r${{ matrix.r_version }}-$(date +%Y%m%d) \
-            --platform linux/amd64 \
+            --platform linux/amd64,linux/arm64 \
             --push \
             .
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,11 @@
   nonexistent `detached = TRUE` argument; S3-read examples used base `read.csv()`/
   `readRDS(url())` which cannot read `s3://`; and the API rate-limit example
   aggregated to 10× its stated global limit across workers.
+* **Public base images are now built multi-arch (amd64 + arm64).** They were
+  published amd64-only, so `use_public_base = TRUE` failed the multi-arch
+  environment build with "no match for platform in manifest" for arm64. The
+  `build-base-images` workflow now builds both architectures (matching the env
+  build), so the public base path works. (#39)
 
 ## Documentation
 


### PR DESCRIPTION
The public base image was published **amd64-only** (`--platform linux/amd64`), but staRburst's env-layer build is **multi-arch** (`--platform linux/amd64,linux/arm64`). So `use_public_base = TRUE` failed with `no match for platform in manifest` for arm64. (The private `base-<ver>` is already multi-arch, which is why `use_public_base = FALSE` worked.) Surfaced by the benchmark harness (#35).

## Fix
- `build-base-images.yml`: `--platform linux/amd64,linux/arm64` (matches the env build).
- Added `docker/setup-qemu-action@v3` so the amd64 runner can emit arm64.
- `:latest` via `buildx imagetools create` copies the multi-arch manifest unchanged.

No R change needed: `get_base_image_source()` already resolves the public tag, and the env build already requests both arches.

## Verification
YAML valid; doc-consistency + R-CMD-check green. The actual multi-arch publish runs on `main` via the workflow (OIDC trusts main only) — I can trigger it post-merge to confirm both arches land in `public.ecr.aws/f8g1e7l5/base`.

Closes #39.
