### PR TITLE
Fourth-review correctness pass: runtime ⇄ docs alignment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,22 @@
   first `starburst_map()`/`plan(starburst)` run failed because no capacity provider
   existed. It is created at `DesiredCapacity = 0` (no billable instances launch
   during setup). Pass `setup_ec2 = FALSE` to skip (Fargate-only users). (#37)
+* **Custom EC2 instance types are now provisioned automatically on first use.**
+  Selecting a non-default `instance_type` (e.g. `c8a.xlarge`) previously failed with
+  an opaque "AutoScalingGroup not found" because only the default was provisioned.
+  Now the capacity provider/ASG is created on demand at first launch (a one-time
+  ~1–2 min step; no instances launched by provisioning), or on failure you get the
+  exact `starburst_setup_ec2(instance_types = "…")` command to run.
+
+## Behavior changes
+
+* **Detached `session$collect()` now returns an entry for every terminal task**,
+  including failures. A failed task comes back as a structured failure
+  (`list(error = TRUE, message = …, task_id = …)`) alongside successful results,
+  instead of being silently omitted — matching the documented contract.
+* Clarified `session$cleanup()`: by default it stops workers and marks the session
+  terminated but **preserves S3 objects**; pass `force = TRUE` to also delete them.
+  (Behavior unchanged; the docs were wrong and are now correct.)
 
 ## Breaking changes
 

--- a/R/ec2-pool.R
+++ b/R/ec2-pool.R
@@ -333,6 +333,32 @@ start_warm_pool <- function(backend, capacity, timeout_seconds = 180) {
   autoscaling <- get_autoscaling_client(region)
   ecs <- get_ecs_client(region)
 
+  # Lazily provision the capacity provider + ASG for this instance type if it
+  # doesn't exist yet. starburst_setup() only provisions the default (c7g.xlarge),
+  # so a custom instance_type (e.g. c8a.xlarge) would otherwise fail here with an
+  # opaque "AutoScalingGroup not found". setup_ec2_capacity_provider() is idempotent.
+  asg_exists <- tryCatch({
+    resp <- autoscaling$describe_auto_scaling_groups(
+      AutoScalingGroupNames = list(asg_name)
+    )
+    length(resp$AutoScalingGroups) > 0
+  }, error = function(e) FALSE)
+
+  if (!asg_exists) {
+    cat_info(sprintf(
+      "[EC2] Capacity provider for %s not found; provisioning it now (once)...\n",
+      backend$instance_type))
+    tryCatch(
+      setup_ec2_capacity_provider(backend),
+      error = function(e) {
+        stop(sprintf(
+          paste0("Could not provision EC2 capacity for instance type '%s': %s\n",
+                 "Provision it once with:\n",
+                 "  starburst_setup_ec2(instance_types = \"%s\")"),
+          backend$instance_type, conditionMessage(e), backend$instance_type))
+      })
+  }
+
   # Scale ASG to desired capacity
   autoscaling$set_desired_capacity(
     AutoScalingGroupName = asg_name,

--- a/R/session-api.R
+++ b/R/session-api.R
@@ -30,14 +30,20 @@ NULL
 #'     \item{\code{status()}}{Return a progress summary (counts of pending / running
 #'       / completed / failed tasks). Safe to call from a fresh R session after
 #'       reattaching.}
-#'     \item{\code{collect(wait = FALSE)}}{Retrieve results. With \code{wait = FALSE}
-#'       returns whatever has completed so far; with \code{wait = TRUE} blocks until
-#'       all submitted tasks finish. Results come back in submission order.}
+#'     \item{\code{collect(wait = FALSE)}}{Retrieve results, keyed by task id, in
+#'       submission order. With \code{wait = FALSE} returns whatever has finished so
+#'       far; \code{wait = TRUE} blocks until every submitted task is terminal.
+#'       Every terminal task appears: a success carries its return value; a
+#'       \strong{failed} task carries a structured failure
+#'       \code{list(error = TRUE, message = ..., value = NULL, task_id = ...)} so
+#'       failures are visible rather than silently dropped.}
 #'     \item{\code{extend(seconds = 3600)}}{Extend the active/absolute timeout of a
 #'       still-running session.}
-#'     \item{\code{cleanup()}}{Stop all tasks/workers for the session and delete its
-#'       S3 objects. Call when done; otherwise the session self-terminates at
-#'       \code{absolute_timeout}.}
+#'     \item{\code{cleanup(stop_workers = TRUE, force = FALSE)}}{Stop the session's
+#'       workers and mark it terminated. By default \strong{S3 objects are
+#'       preserved} (so you can still inspect/collect); pass \code{force = TRUE} to
+#'       also delete the session's S3 task/result objects. Otherwise the session
+#'       self-terminates at \code{absolute_timeout}.}
 #'   }
 #'
 #' @section Lifecycle:
@@ -50,7 +56,9 @@ NULL
 #'
 #' @section Failure behavior:
 #' A failed task is recorded (surfaced via \code{status()}) and does not abort the
-#' others; its error is raised when you \code{collect()} that result. If the client
+#' others; \code{collect()} returns it as a structured failure entry
+#' (\code{error = TRUE} with a \code{message}) alongside the successful results,
+#' rather than dropping it or raising. If the client
 #' dies, workers keep running against S3 until a timeout, which is what makes
 #' reattaching possible. \code{cleanup()} is the only thing that frees resources
 #' early — sessions do not auto-clean on garbage collection.
@@ -438,7 +446,11 @@ collect_session_results <- function(session, wait, timeout) {
       bucket = backend$bucket
     )
 
-    # Collect completed results that we haven't collected yet
+    # Collect terminal (completed OR failed) results we haven't collected yet.
+    # Every submitted task ends up in the returned list keyed by task id: a
+    # successful task carries its value; a failed task carries a structured
+    # failure (error = TRUE, message, task_id) so failures are visible rather
+    # than silently dropped.
     for (task_id in names(statuses)) {
       # Skip bootstrap tasks
       if (grepl("^bootstrap-", task_id)) {
@@ -447,12 +459,14 @@ collect_session_results <- function(session, wait, timeout) {
 
       status <- statuses[[task_id]]
 
-      # Skip if not completed or already collected
-      if (status$state != "completed" || task_id %in% names(results)) {
+      # Skip if not terminal yet, or already collected
+      if (!status$state %in% c("completed", "failed") ||
+          task_id %in% names(results)) {
         next
       }
 
-      # Download result from S3
+      # Download the result/error blob from S3 (workers upload an error result
+      # for failed tasks too). Fall back to a structured failure from the status.
       result_key <- sprintf("results/%s.qs", task_id)
       temp_file <- tempfile(fileext = ".qs")
 
@@ -463,11 +477,20 @@ collect_session_results <- function(session, wait, timeout) {
           Filename = temp_file
         )
 
-        result_data <- qs2::qs_read(temp_file)
-        results[[task_id]] <- result_data
+        results[[task_id]] <- qs2::qs_read(temp_file)
       }, error = function(e) {
-        cat_warn(sprintf("Failed to download result for task %s: %s\n",
-                        task_id, e$message))
+        if (identical(status$state, "failed")) {
+          # No or unreadable error blob: synthesize a structured failure.
+          results[[task_id]] <<- list(
+            error = TRUE,
+            message = status$error %||% "task failed (no error detail available)",
+            value = NULL,
+            task_id = task_id
+          )
+        } else {
+          cat_warn(sprintf("Failed to download result for task %s: %s\n",
+                          task_id, e$message))
+        }
       }, finally = {
         unlink(temp_file)
       })

--- a/man/starburst_session.Rd
+++ b/man/starburst_session.Rd
@@ -50,14 +50,20 @@ A \code{StarburstSession} object (also carrying \code{$session_id}, the
     \item{\code{status()}}{Return a progress summary (counts of pending / running
       / completed / failed tasks). Safe to call from a fresh R session after
       reattaching.}
-    \item{\code{collect(wait = FALSE)}}{Retrieve results. With \code{wait = FALSE}
-      returns whatever has completed so far; with \code{wait = TRUE} blocks until
-      all submitted tasks finish. Results come back in submission order.}
+    \item{\code{collect(wait = FALSE)}}{Retrieve results, keyed by task id, in
+      submission order. With \code{wait = FALSE} returns whatever has finished so
+      far; \code{wait = TRUE} blocks until every submitted task is terminal.
+      Every terminal task appears: a success carries its return value; a
+      \strong{failed} task carries a structured failure
+      \code{list(error = TRUE, message = ..., value = NULL, task_id = ...)} so
+      failures are visible rather than silently dropped.}
     \item{\code{extend(seconds = 3600)}}{Extend the active/absolute timeout of a
       still-running session.}
-    \item{\code{cleanup()}}{Stop all tasks/workers for the session and delete its
-      S3 objects. Call when done; otherwise the session self-terminates at
-      \code{absolute_timeout}.}
+    \item{\code{cleanup(stop_workers = TRUE, force = FALSE)}}{Stop the session's
+      workers and mark it terminated. By default \strong{S3 objects are
+      preserved} (so you can still inspect/collect); pass \code{force = TRUE} to
+      also delete the session's S3 task/result objects. Otherwise the session
+      self-terminates at \code{absolute_timeout}.}
   }
 }
 \description{
@@ -77,7 +83,9 @@ elapses with no activity, or at \code{absolute_timeout} — whichever comes firs
 \section{Failure behavior}{
 
 A failed task is recorded (surfaced via \code{status()}) and does not abort the
-others; its error is raised when you \code{collect()} that result. If the client
+others; \code{collect()} returns it as a structured failure entry
+(\code{error = TRUE} with a \code{message}) alongside the successful results,
+rather than dropping it or raising. If the client
 dies, workers keep running against S3 until a timeout, which is what makes
 reattaching possible. \code{cleanup()} is the only thing that frees resources
 early — sessions do not auto-clean on garbage collection.

--- a/tests/testthat/test-detached-sessions.R
+++ b/tests/testthat/test-detached-sessions.R
@@ -267,3 +267,37 @@ test_that("collect(wait=TRUE) returns when user tasks finish despite live bootst
   expect_named(res, c("task-aaa", "task-bbb"), ignore.order = TRUE)
   expect_lt(elapsed, 10)  # returned promptly, did not spin to timeout
 })
+
+test_that("collect() returns a structured failure entry for failed tasks", {
+  # Regression for the 4th-review finding: collect() must NOT silently drop
+  # failed tasks. Every terminal task appears; failures carry error=TRUE.
+  skip_if_not_installed("mockery")
+
+  statuses <- list(
+    "bootstrap-session-x-1" = list(state = "claimed"),
+    "task-ok"   = list(state = "completed"),
+    "task-fail" = list(state = "failed", error = "boom")
+  )
+  mockery::stub(collect_session_results, "list_task_statuses", function(...) statuses)
+  # S3 has the success blob but NOT the failed one -> exercises the synthesize path.
+  mockery::stub(collect_session_results, "get_s3_client", function(...) {
+    list(download_file = function(Bucket, Key, Filename) {
+      if (grepl("task-ok", Key)) {
+        qs2::qs_save(list(error = FALSE, value = 21), Filename)
+      } else {
+        stop("NoSuchKey")   # failed task's blob missing
+      }
+    })
+  })
+
+  session <- list(backend = list(session_id = "session-x", region = "us-east-1",
+                                 bucket = "b"))
+  res <- collect_session_results(session, wait = TRUE, timeout = 30)
+
+  expect_setequal(names(res), c("task-ok", "task-fail"))
+  expect_false(isTRUE(res[["task-ok"]]$error))
+  expect_equal(res[["task-ok"]]$value, 21)
+  # failed task present as a structured failure, synthesized from status$error
+  expect_true(isTRUE(res[["task-fail"]]$error))
+  expect_match(res[["task-fail"]]$message, "boom")
+})

--- a/tests/testthat/test-ec2-pool.R
+++ b/tests/testthat/test-ec2-pool.R
@@ -1,0 +1,53 @@
+test_that("start_warm_pool lazily provisions a missing capacity provider", {
+  skip_if_not_installed("mockery")
+
+  backend <- list(
+    region = "us-east-1", cluster = "starburst-cluster",
+    cluster_name = "starburst-cluster", instance_type = "c8a.xlarge",
+    architecture = "X86_64", use_spot = TRUE,
+    capacity_provider_name = "starburst-c8a-xlarge",
+    asg_name = "starburst-asg-c8a-xlarge", workers = 5
+  )
+
+  # ASG does NOT exist -> empty AutoScalingGroups.
+  autoscaling <- list(
+    describe_auto_scaling_groups = function(...) list(AutoScalingGroups = list()),
+    set_desired_capacity = function(...) stop("stop-after-provision")  # sentinel
+  )
+  mockery::stub(start_warm_pool, "get_autoscaling_client", function(...) autoscaling)
+  mockery::stub(start_warm_pool, "get_ecs_client", function(...) list())
+
+  provisioned <- mockery::mock(invisible(TRUE))
+  mockery::stub(start_warm_pool, "setup_ec2_capacity_provider", provisioned)
+
+  # Missing ASG -> provision, then hit the set_desired_capacity sentinel.
+  expect_error(start_warm_pool(backend, capacity = 5), "stop-after-provision")
+  mockery::expect_called(provisioned, 1)
+})
+
+test_that("start_warm_pool does NOT re-provision an existing capacity provider", {
+  skip_if_not_installed("mockery")
+
+  backend <- list(
+    region = "us-east-1", cluster = "starburst-cluster",
+    cluster_name = "starburst-cluster", instance_type = "c7g.xlarge",
+    architecture = "ARM64", use_spot = TRUE,
+    capacity_provider_name = "starburst-c7g-xlarge",
+    asg_name = "starburst-asg-c7g-xlarge", workers = 5
+  )
+
+  # ASG already exists.
+  autoscaling <- list(
+    describe_auto_scaling_groups = function(...)
+      list(AutoScalingGroups = list(list(AutoScalingGroupName = backend$asg_name))),
+    set_desired_capacity = function(...) stop("stop-after-scale")  # sentinel
+  )
+  mockery::stub(start_warm_pool, "get_autoscaling_client", function(...) autoscaling)
+  mockery::stub(start_warm_pool, "get_ecs_client", function(...) list())
+
+  provisioned <- mockery::mock(invisible(TRUE))
+  mockery::stub(start_warm_pool, "setup_ec2_capacity_provider", provisioned)
+
+  expect_error(start_warm_pool(backend, capacity = 5), "stop-after-scale")
+  mockery::expect_called(provisioned, 0)  # existing ASG -> no provisioning
+})

--- a/tools/check-docs.R
+++ b/tools/check-docs.R
@@ -40,10 +40,21 @@ banned <- c("future_starburst", "starburst_upload", "yourname/starburst",
             # removed/renamed args that must not reappear in docs or code:
             "detached = TRUE",   # starburst_session has no `detached` arg
             "max_cost_per_job",  # renamed to max_hourly_cost
-            "readRDS(url(")      # base url() can't read s3:// — use an S3 client
+            "readRDS(url(",      # base url() can't read s3:// — use an S3 client
+            # obsolete engine/backend terminology (no auto-chunking; EC2 default):
+            "Fargate workers")   # workers are EC2 by default; Fargate is opt-in
 scan_targets <- c(vignettes, readme, r_files)
+# Obsolete chunking language (regex): the engine creates one task per element and
+# does NOT auto-chunk, so any "Created N chunks" output is fabricated.
+banned_re <- c("Created\\s+[0-9]+\\s+chunks")
 for (f in scan_targets) {
   lines <- read_lines_safe(f)
+  for (re in banned_re) {
+    for (h in grep(re, lines)) {
+      note(sprintf("[obsolete-term] %s:%d matches /%s/ — the engine does not auto-chunk",
+                   sub(paste0("^", pkg_root, "/?"), "", f), h, re))
+    }
+  }
   for (b in banned) {
     hits <- grep(b, lines, fixed = TRUE)
     for (h in hits) {
@@ -152,6 +163,26 @@ for (f in c(vignettes, readme)) {
       note(sprintf("[naive-big-count] %s:%d starburst_map(1:%d, ...) — model batching or mark it as an anti-pattern (# DON'T / # Bad:)",
                    basename(f), h, n))
     }
+  }
+}
+
+# ---- 6. Fabricated performance claims in example vignettes -------------------
+# The measured performance/workload-shapes guides are the single source of truth.
+# Example vignettes must NOT present hand-written performance as if measured. Two
+# tells, both flagged (only in example-*.Rmd; the measured guides are exempt):
+#   (a) a "Typical output" label (implies measured) on a console block — use
+#       "Illustrative output" instead;
+#   (b) a fabricated speedup table row like `| staRburst | ... | 24.3x |`.
+example_vigs <- Filter(function(p) grepl("/example-", p), vignettes)
+for (f in example_vigs) {
+  lines <- read_lines_safe(f)
+  for (h in grep("Typical output", lines, ignore.case = TRUE)) {
+    note(sprintf("[unmeasured-output] %s:%d 'Typical output' implies measured — label example console output 'Illustrative output'",
+                 basename(f), h))
+  }
+  for (h in grep("\\|\\s*[0-9]+(\\.[0-9]+)?x\\s*\\|", lines)) {
+    note(sprintf("[fabricated-speedup] %s:%d speedup table row — remove; point to vignette(\"performance\")/vignette(\"workload-shapes\") for measured numbers",
+                 basename(f), h))
   }
 }
 

--- a/vignettes/detached-sessions.Rmd
+++ b/vignettes/detached-sessions.Rmd
@@ -130,13 +130,15 @@ session$cleanup()
 ## Choosing and tuning the backend
 
 Sessions use **EC2 with Spot instances by default** — no extra arguments needed.
-You can tune the instance type, or opt into Fargate:
+You can tune the instance type, or opt into Fargate. A non-default instance type is
+provisioned automatically on first use (a one-time ~1–2 min step), or run
+`starburst_setup_ec2(instance_types = "c8a.xlarge")` once to pre-provision it.
 
 ```{r}
-# Default is already EC2 + Spot; override the instance type if you like
+# Default is already EC2 + Spot (c7g.xlarge); override the instance type if you like
 session <- starburst_session(
   workers = 50,
-  instance_type = "c8a.xlarge",  # AMD 8th gen; default is c7g.xlarge
+  instance_type = "c8a.xlarge",  # AMD 8th gen; auto-provisioned on first use
   use_spot = TRUE                 # default TRUE — ~70% cheaper
 )
 

--- a/vignettes/detached-sessions.Rmd
+++ b/vignettes/detached-sessions.Rmd
@@ -123,8 +123,12 @@ session$extend(seconds = 3600)
 ### Cleanup
 
 ```{r}
-# Terminate workers and mark session complete
+# Stop workers and mark the session terminated. S3 objects are PRESERVED by
+# default, so you can still reattach and collect afterwards.
 session$cleanup()
+
+# To also delete the session's S3 task/result objects, pass force = TRUE:
+session$cleanup(force = TRUE)
 ```
 
 ## Choosing and tuning the backend
@@ -154,28 +158,31 @@ session <- starburst_session(
 ### Error Handling
 
 ```{r}
-# Tasks that fail are tracked
+# Tasks that fail are tracked, not silently dropped
 session <- starburst_session(workers = 5)
 
-lapply(1:10, function(i) {
+task_ids <- lapply(1:10, function(i) {
   session$submit(quote({
     if (i == 5) stop("Intentional error")
     i * 2
-  }))
+  }), globals = list(i = i))
 })
 
 # Check status
 status <- session$status()
-print(status)
-# Failed: 1
+print(status)   # Failed: 1
 
-# Failed tasks are still in results with error info
+# collect() returns an entry for EVERY task, keyed by task id. A failed task
+# comes back as a structured failure (error = TRUE) alongside the successes.
 results <- session$collect(wait = TRUE)
-failed_task <- results[[5]]
-print(failed_task$error)
-# TRUE
-print(failed_task$message)
-# "Intentional error"
+
+# Separate successes from failures
+failures <- Filter(function(r) isTRUE(r$error), results)
+length(failures)                 # 1
+print(failures[[1]]$message)     # "Intentional error"
+
+# Successful values are the non-error entries
+successes <- Filter(function(r) !isTRUE(r$error), results)
 ```
 
 ### Partial Collection

--- a/vignettes/example-api-calls.Rmd
+++ b/vignettes/example-api-calls.Rmd
@@ -172,7 +172,7 @@ cat(sprintf("  Estimated time for %d: %.1f minutes\n",
             n_companies, local_time * n_companies / 50 / 60))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 Fetching data for 1000 companies locally...
 [OK] Completed 50 calls in 24.3 seconds
@@ -183,26 +183,35 @@ Fetching data for 1000 companies locally...
 
 Run all 1,000 API calls in parallel:
 
+Each fetch is short, so submitting 1,000 one-call tasks would be dominated by
+per-task S3 overhead (see the
+[Workload Shapes](https://starburst.ing/articles/workload-shapes.html) guide).
+Instead, batch the tickers into ~100 tasks and have each task fetch its chunk:
+
 ```{r cloud, eval=FALSE}
 cat(sprintf("Fetching data for %d companies on AWS...\n", n_companies))
 
+# ~100 tasks, each fetching a chunk of tickers
+batches <- split(tickers, ceiling(seq_along(tickers) / ceiling(length(tickers) / 100)))
 results <- starburst_map(
-  tickers,
-  fetch_company_data_mock,
+  batches,
+  function(batch) lapply(batch, fetch_company_data_mock),
   workers = 25,
   cpu = 1,
   memory = "2GB"
 )
+results <- unlist(results, recursive = FALSE)  # flatten to 1,000 results
 ```
 
-**Typical output**:
+**Illustrative output** (times/cost vary — see the Workload Shapes and Performance
+guides for measured numbers):
 ```
 [Starting] Starting starburst cluster with 25 workers
-[Status] Processing 1000 items with 25 workers
-[Starting] Submitting 1000 tasks...
-[Wait] Progress: 1000/1000 (48.0s)
-[OK] Completed in 48.0 seconds
-[Cost] Estimated cost: $0.01
+[Status] Processing 100 items with 25 workers
+[Starting] Submitting 100 tasks...
+[Wait] Progress: 100/100
+[OK] Completed
+[Cost] Estimated cost: (printed per run)
 ```
 
 ## Results Processing
@@ -268,20 +277,10 @@ cat(sprintf("Range: $%.2fB - $%.2fB\n",
             max(results_df$market_cap, na.rm = TRUE) / 1e9))
 ```
 
-## Performance Comparison
+## Performance
 
-| Method | Workers | Time | Cost | Speedup |
-|--------|---------|------|------|---------|
-| Local | 1 | 8.1 min | $0 | 1x |
-| staRburst | 10 | 2.1 min | $0.004 | 3.9x |
-| staRburst | 25 | 0.8 min | $0.01 | 10.1x |
-| staRburst | 50 | 0.5 min | $0.02 | 16.2x |
-
-**Key Insights**:
-- Excellent scaling for I/O-bound workloads
-- Cost remains minimal even with 50 workers
-- Network latency dominates computation time
-- Automatic retries handle transient failures
+For measured performance and when bursting is worth it, see
+`vignette("performance")` and `vignette("workload-shapes")`.
 
 ## Rate Limiting Considerations
 

--- a/vignettes/example-bootstrap.Rmd
+++ b/vignettes/example-bootstrap.Rmd
@@ -127,7 +127,7 @@ local_time <- as.numeric(difftime(Sys.time(), local_start, units = "secs"))
 cat(sprintf("[OK] Completed in %.2f seconds\n\n", local_time))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 Running 1000 bootstrap iterations locally...
 [OK] Completed in 2.1 seconds
@@ -153,7 +153,7 @@ results <- starburst_map(
 )
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 [Starting] Starting starburst cluster with 25 workers
 [Status] Processing 10000 items with 25 workers
@@ -206,7 +206,7 @@ cat(sprintf("95%% CI for relative lift: [%.1f%%, %.1f%%]\n",
             quantile(relative_lifts, 0.975) * 100))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 === Bootstrap Results (10,000 iterations) ===
 

--- a/vignettes/example-feature-engineering.Rmd
+++ b/vignettes/example-feature-engineering.Rmd
@@ -190,7 +190,7 @@ cat(sprintf("  Estimated time for all %s customers: %.1f minutes\n",
             local_time * (n_customers / 500) / 60))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 Processing features for 500 customers locally...
 [OK] Completed in 3.8 seconds
@@ -238,7 +238,7 @@ cat(sprintf("\n[OK] Completed in %.1f seconds\n", cloud_time))
 features <- do.call(rbind, results)
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 [Starting] Starting starburst cluster with 20 workers
 [Status] Processing 20 items with 20 workers
@@ -290,7 +290,7 @@ cat(sprintf("Average transactions: %.1f\n", mean(high_value$total_transactions))
 cat(sprintf("Average online rate: %.1f%%\n", mean(high_value$online_pct)))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 === Feature Engineering Results ===
 

--- a/vignettes/example-geospatial.Rmd
+++ b/vignettes/example-geospatial.Rmd
@@ -248,7 +248,7 @@ cat(sprintf("  Estimated time for all %d regions: %.1f seconds\n",
             nrow(regions), local_time * (nrow(regions) / length(test_regions))))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 Analyzing 3 regions locally...
 [OK] Completed in 4.5 seconds
@@ -288,7 +288,7 @@ cat(sprintf("\n[OK] Completed in %.1f seconds\n", cloud_time))
 spatial_metrics <- do.call(rbind, results)
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 [Starting] Starting starburst cluster with 20 workers
 [Status] Processing 20 items with 20 workers
@@ -376,7 +376,7 @@ for (i in 1:min(5, nrow(region_summary))) {
 }
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 === Geospatial Analysis Results ===
 

--- a/vignettes/example-grid-search.Rmd
+++ b/vignettes/example-grid-search.Rmd
@@ -213,7 +213,7 @@ cat(sprintf("  Estimated time for full grid (%d combinations): %.1f minutes\n",
             nrow(param_grid), local_time * nrow(param_grid) / nrow(sample_params)))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 Running local benchmark (10 parameter combinations)...
 [OK] Completed in 4.2 minutes
@@ -227,35 +227,49 @@ For full grid search locally: **~34 minutes**
 
 Run the complete grid search in parallel on AWS:
 
+Each `cv_evaluate` is short, so submitting 81 one-combination tasks would be
+dominated by per-task S3 overhead (see the
+[Workload Shapes](https://starburst.ing/articles/workload-shapes.html) guide).
+Instead, batch the combinations into at most ~100 tasks and have each task evaluate
+its chunk (this small 81-cell grid stays near one combination per task, but the same
+pattern keeps larger grids from over-submitting):
+
 ```{r cloud, eval=FALSE}
-n_workers <- 27  # Process ~3 parameter combinations per worker
+n_workers <- 27
 
 cat(sprintf("Running grid search (%d combinations) on %d workers...\n",
             nrow(param_grid), n_workers))
 
 cloud_start <- Sys.time()
 
+# Batch the parameter rows into ~100 tasks, each evaluating a chunk
+idx <- 1:nrow(param_grid)
+batches <- split(idx, ceiling(seq_along(idx) / ceiling(length(idx) / 100)))
 results <- starburst_map(
-  1:nrow(param_grid),
-  function(i) cv_evaluate(param_grid[i, ], X_train, y_train, n_folds = 5),
+  batches,
+  function(chunk) lapply(chunk, function(i) {
+    cv_evaluate(param_grid[i, ], X_train, y_train, n_folds = 5)
+  }),
   workers = n_workers,
   cpu = 2,
   memory = "4GB"
 )
+results <- unlist(results, recursive = FALSE)  # flatten to one result per combination
 
 cloud_time <- as.numeric(difftime(Sys.time(), cloud_start, units = "mins"))
 
 cat(sprintf("\n[OK] Completed in %.2f minutes\n", cloud_time))
 ```
 
-**Typical output**:
+**Illustrative output** (times/cost vary — see the Workload Shapes and Performance
+guides for measured numbers):
 ```
 [Starting] Starting starburst cluster with 27 workers
 [Status] Processing 81 items with 27 workers
 [Starting] Submitting 81 tasks...
-[Wait] Progress: 81/81 (84.0s)
-[OK] Completed in 84.0 seconds
-[Cost] Estimated cost: $0.05
+[Wait] Progress: 81/81
+[OK] Completed
+[Cost] Estimated cost: (printed per run)
 ```
 
 ## Results Analysis
@@ -332,7 +346,7 @@ if (interactive()) {
 }
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 === Grid Search Results ===
 
@@ -385,19 +399,10 @@ min_child_weight:
   5: 0.7576
 ```
 
-## Performance Comparison
+## Performance
 
-| Method | Combinations | Time | Cost | Speedup |
-|--------|--------------|------|------|---------|
-| Local | 10 | 4.2 min | $0 | - |
-| Local (est.) | 81 | 34 min | $0 | 1x |
-| staRburst | 81 | 1.4 min | $0.05 | 24.3x |
-
-**Key Insights**:
-- Excellent speedup (24x) for grid search
-- Cost remains minimal ($0.05) despite massive parallelization
-- Can evaluate 81 combinations in the time it takes to run ~3 locally
-- Enables exploration of much larger parameter spaces
+For measured performance and when bursting is worth it, see
+`vignette("performance")` and `vignette("workload-shapes")`.
 
 ## Advanced: Random Search
 

--- a/vignettes/example-reports.Rmd
+++ b/vignettes/example-reports.Rmd
@@ -237,7 +237,7 @@ cat(sprintf("  Estimated time for %d reports: %.1f minutes\n\n",
             n_customers, (local_time / 5 * n_customers) / 60))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 Rendering 5 reports locally...
 [OK] Completed in 23.4 seconds
@@ -264,7 +264,7 @@ results <- starburst_map(
 )
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 [Starting] Starting starburst cluster with 25 workers
 [Status] Processing 50 items with 25 workers
@@ -305,7 +305,7 @@ report_files <- sapply(successful_results[1:10], function(x) x$output_file)
 print(report_files)
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 === Report Generation Summary ===
 
@@ -326,26 +326,17 @@ Generated reports:
  [9] "report_CUST009.html" "report_CUST010.html"
 ```
 
-## Performance Comparison
+## Performance
 
-| Method | Reports | Compute time | Cost | Speedup |
-|--------|---------|------|------|---------|
-| Local | 50 | 3.9 min | $0 | 1x |
-| staRburst | 50 (10 workers) | 1.2 min | $0.004 | 3.3x |
-| staRburst | 50 (25 workers) | 0.4 min | $0.01 | 9.8x |
-| staRburst | 50 (50 workers) | 0.3 min | $0.02 | 13x |
+Report generation is a **genuine fit** for bursting: each report takes ~1–2 minutes
+to render, so with dozens-to-hundreds of them the per-task work dwarfs the one-time
+startup — exactly the shape that wins (unlike the seconds-scale demos). One report
+per task is the right granularity here (no batching needed).
 
-> **Disclosure:** staRburst rows are *compute time on a warm pool* and exclude the
-> one-time startup (~2 minutes) and image pull. Unlike the seconds-scale demos,
-> this workload is a genuine fit — each report takes 1–2 minutes, so even with
-> startup added the 25–50-worker runs come out well ahead of the 3.9-minute local
-> baseline, and more so at 500+ reports.
-
-**Key Insights**:
-- Near-linear scaling with worker count
-- Sweet spot: 25-50 workers for this workload
-- Minimal cost ($0.01) for significant time savings
-- A good fit for bursting because per-report work is minutes, not seconds
+We don't hand-write speedup tables in the examples. For **measured** numbers — a
+workload where the cloud wins, one where it loses, and how to size workers — see
+`vignette("performance")` and `vignette("workload-shapes")`, and regenerate figures
+for your own workload with `bench/benchmark.R`.
 
 ## Advanced: Custom Report Distribution
 

--- a/vignettes/example-risk-modeling.Rmd
+++ b/vignettes/example-risk-modeling.Rmd
@@ -264,7 +264,7 @@ cat(sprintf("  Estimated time for 10,000 scenarios: %.1f minutes\n",
             local_time * 10000 / length(test_scenarios) / 60))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 Running local benchmark (120 scenarios)...
 [OK] Completed in 8.4 seconds
@@ -302,21 +302,29 @@ cat(sprintf("Running risk analysis (%s scenarios) on %d workers...\n",
 
 cloud_start <- Sys.time()
 
-results <- starburst_map(
+# Each scenario is tiny (~1 ms), so submitting 10,145 one-scenario tasks would be
+# dominated by per-task S3 overhead (see the Workload Shapes guide). Batch into
+# ~100 tasks, each valuing a chunk of scenarios.
+batches <- split(
   all_scenarios,
-  value_portfolio_scenario,
-  portfolio_data = portfolio,
+  ceiling(seq_along(all_scenarios) / ceiling(length(all_scenarios) / 100))
+)
+results <- starburst_map(
+  batches,
+  function(batch) lapply(batch, value_portfolio_scenario, portfolio_data = portfolio),
   workers = n_workers,
   cpu = 2,
   memory = "4GB"
 )
+results <- unlist(results, recursive = FALSE)  # flatten to one result per scenario
 
 cloud_time <- as.numeric(difftime(Sys.time(), cloud_start, units = "mins"))
 
 cat(sprintf("\n[OK] Completed in %.2f minutes\n", cloud_time))
 ```
 
-**Typical output**:
+**Illustrative output** (times/cost vary — see the Workload Shapes and Performance
+guides for measured numbers):
 ```
 Generating scenario sets...
   Stress test scenarios: 100
@@ -325,11 +333,11 @@ Generating scenario sets...
   Total scenarios: 10,145
 
 [Starting] Starting starburst cluster with 50 workers
-[Status] Processing 10145 items with 50 workers
-[Starting] Submitting 10145 tasks...
-[Wait] Progress: 10145/10145 (108.0s)
-[OK] Completed in 108.0 seconds
-[Cost] Estimated cost: $0.12
+[Status] Processing 100 items with 50 workers
+[Starting] Submitting 100 tasks...
+[Wait] Progress: 100/100
+[OK] Completed
+[Cost] Estimated cost: (printed per run)
 ```
 
 ## Risk Metrics Analysis
@@ -419,7 +427,7 @@ cat(sprintf("Capital as %% of Portfolio: %.2f%%\n",
             market_risk_capital / total_portfolio_value * 100))
 ```
 
-**Typical output**:
+**Illustrative output**:
 ```
 === Comprehensive Risk Analysis Results ===
 
@@ -460,19 +468,10 @@ Market Risk Capital Requirement: $29,629,629
 Capital as % of Portfolio: 47.44%
 ```
 
-## Performance Comparison
+## Performance
 
-| Method | Scenarios | Time | Cost | Speedup |
-|--------|-----------|------|------|---------|
-| Local | 120 | 8.4 sec | $0 | - |
-| Local (est.) | 10,145 | 11.9 min | $0 | 1x |
-| staRburst | 10,145 | 1.8 min | $0.12 | 6.6x |
-
-**Key Insights**:
-- Excellent speedup (6.6x) for risk calculations
-- Enables daily comprehensive risk reporting
-- Cost-effective even for large portfolios
-- Can scale to 100,000+ scenarios for more precision
+For measured performance and when bursting is worth it, see
+`vignette("performance")` and `vignette("workload-shapes")`.
 
 ## Advanced: Incremental Risk Analysis
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -113,7 +113,11 @@ This will:
 - Validate your AWS credentials
 - Create an S3 bucket for data transfer
 - Create an ECR repository for Docker images
-- Set up ECS cluster and VPC resources
+- Set up an ECS cluster and VPC resources
+- Provision the **default EC2 capacity** (launch template + Auto Scaling Group +
+  capacity provider for `c7g.xlarge`) so the default EC2 backend works immediately
+  — created at zero instances, so no compute cost until you run a job
+  (skip with `setup_ec2 = FALSE` if you only use Fargate)
 - Check Fargate quotas and offer to request increases
 - Build the initial worker image
 

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -128,15 +128,24 @@ batch_size <- ceiling(target_task_duration / per_item_time)
 
 ## Choosing Instance Types
 
+The **default** instance type is `c7g.xlarge` (Graviton, ARM64) — provisioned
+automatically by `starburst_setup()`. The types below are strong alternatives:
+
 | Instance | Architecture | Price/Perf | Best For |
 |----------|-------------|------------|----------|
-| **c8a** | AMD 8th gen | ★★★★★ | Default — best overall |
+| **c8a** | AMD 8th gen | ★★★★★ | Recommended — best overall price/perf |
 | **c8g** | Graviton4 ARM | ★★★★ | Best ARM64 option |
 | **c7a** | AMD 7th gen | ★★★★ | Proven, stable |
 | **c8i** | Intel 8th gen | ★★★ | High single-thread needs |
 
+> **Custom instance types provision on first use.** `starburst_setup()` provisions
+> only the default (`c7g.xlarge`). The first time you use a *different* type,
+> staRburst automatically creates its capacity provider (a one-time ~1–2 min step,
+> no instances launched by provisioning). To pre-provision explicitly, run
+> `starburst_setup_ec2(instance_types = "c8a.xlarge")` once.
+
 ```{r instance-choice}
-# Recommended: c8a with spot instances
+# Recommended alternative: c8a with spot instances (auto-provisioned on first use)
 plan(starburst,
   workers     = 50,
   instance_type = "c8a.xlarge",  # AMD 8th gen — best price/performance


### PR DESCRIPTION
Fourth-review correctness pass. I verified every claim against current source with parallel audits — a **mix**: some were stale (reviewer inspected old source/CRAN), the rest confirmed and fixed here.

## Verified already-correct (no change) — reviewer saw stale source
- **#3 cost guardrail**: `plan-starburst.R` already reads `config$max_hourly_cost` (fixed in #45). The claim it still uses `max_cost_per_job` is false against main.
- **#2(a) Monte Carlo 72.4s/19x**: already batched + "Illustrative".
- **#5 README obsolete terms**: `max_cost_per_job`/`future_starburst`/`platform =`/`50 chunks` — none present.
- **Live site is current, not cached**: `starburst.ing` serves 0.3.9 content (`max_hourly_cost`, batched Monte Carlo). Deploy pipeline healthy.

## Fixed (confirmed)
**#1 — custom EC2 types now provision on first use.** `plan(starburst, instance_type="c8a.xlarge")` previously failed opaquely (only the default was provisioned). `start_warm_pool()` now creates the capacity provider/ASG on demand (idempotent `setup_ec2_capacity_provider`), or errors with the exact `starburst_setup_ec2()` command. Docs: c8a "Default"→"Recommended" (real default is c7g.xlarge) + first-use callouts.

**#4 — detached sessions match docs.** `collect()` now returns an entry for **every** terminal task — failures come back as structured `list(error=TRUE, message=…)` instead of being silently dropped. `cleanup()` roxygen + vignette corrected: preserves S3 by default, deletes with `force=TRUE`.

**#2(b/c/d) — stale examples fixed.** api-calls / grid-search / risk-modeling rewritten to the batched pattern, output relabeled "Illustrative", fabricated speedup tables removed → point to the measured guides. Swept all example vignettes for the same ("Typical output" → "Illustrative"; removed reports' speedup table).

**Guard strengthened** (`tools/check-docs.R`): now flags `Typical output` labels + `| Nx |` speedup rows in example vignettes, and bans `Fargate workers` / `Created N chunks`. (The old naive-count check only caught literal `1:N`; these catch the named-variable cases.)

**Setup checklist**: getting-started "This will:" now lists the default EC2 capacity-provider provisioning.

## Verification
`devtools::check()` → **0/0/0**; full suite **240 pass / 0 fail** (+9 new tests: lazy-provision ×2, collect-failure); `tools/check-docs.R` passes and fails on reintroduction. NEWS 0.3.9 documents the behavior changes. Post-merge I'll re-confirm the pkgdown deploy lands on the live site.
