### PR TITLE
release: staRburst 0.3.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# starburst 0.3.9 (development)
+# starburst 0.3.9 (2026-07-22)
 
 ## Cost & cleanup fixes (important)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,20 +40,14 @@ staRburst lets you run parallel R code on AWS with zero infrastructure managemen
 
 ## Installation
 
-> **Note on versions.** This documentation describes the **development version,
-> 0.3.9**. The current CRAN release is **0.3.8**, which does **not** include some
-> APIs documented here (notably backend arguments — `launch_type`/`instance_type`/
-> `use_spot` — on `starburst_map()` and `starburst_cluster()`). To use the APIs as
-> documented, install from GitHub.
-
-Development version (0.3.9 — matches this documentation):
-```r
-remotes::install_github("scttfrdmn/starburst")
-```
-
-Latest CRAN release (0.3.8):
+From CRAN:
 ```r
 install.packages("starburst")
+```
+
+Development version (from GitHub):
+```r
+remotes::install_github("scttfrdmn/starburst")
 ```
 
 ## Quick Start
@@ -284,12 +278,13 @@ For detailed setup instructions, see the [Getting Started](https://starburst.ing
 
 ## Roadmap
 
-### v0.3.9 (development — this documentation)
+### v0.3.9 (current CRAN release)
 - ✅ Backend arguments (`launch_type`/`instance_type`/`use_spot`) on `starburst_map()`/`starburst_cluster()`
 - ✅ One-step EC2 setup (`starburst_setup()` provisions the default capacity provider)
+- ✅ Live AWS pricing for cost estimates (Pricing API + spot history, cached)
 - ✅ Measured performance/workload-shape guides
 
-### v0.3.8 (current CRAN release)
+### v0.3.8
 - ✅ Direct API (`starburst_map`, `starburst_cluster`)
 - ✅ EC2 backend (default, with spot instances) + Fargate (serverless alternative)
 - ✅ Detached session mode for long-running jobs

--- a/README.md
+++ b/README.md
@@ -39,23 +39,16 @@ and Fargate (serverless) backends.
 
 ## Installation
 
-> **Note on versions.** This documentation describes the **development
-> version, 0.3.9**. The current CRAN release is **0.3.8**, which does
-> **not** include some APIs documented here (notably backend arguments —
-> `launch_type`/`instance_type`/ `use_spot` — on `starburst_map()` and
-> `starburst_cluster()`). To use the APIs as documented, install from
-> GitHub.
-
-Development version (0.3.9 — matches this documentation):
-
-``` r
-remotes::install_github("scttfrdmn/starburst")
-```
-
-Latest CRAN release (0.3.8):
+From CRAN:
 
 ``` r
 install.packages("starburst")
+```
+
+Development version (from GitHub):
+
+``` r
+remotes::install_github("scttfrdmn/starburst")
 ```
 
 ## Quick Start
@@ -297,15 +290,17 @@ Started](https://starburst.ing/articles/getting-started.html) guide.
 
 ## Roadmap
 
-### v0.3.9 (development — this documentation)
+### v0.3.9 (current CRAN release)
 
 - ✅ Backend arguments (`launch_type`/`instance_type`/`use_spot`) on
   `starburst_map()`/`starburst_cluster()`
 - ✅ One-step EC2 setup (`starburst_setup()` provisions the default
   capacity provider)
+- ✅ Live AWS pricing for cost estimates (Pricing API + spot history,
+  cached)
 - ✅ Measured performance/workload-shape guides
 
-### v0.3.8 (current CRAN release)
+### v0.3.8
 
 - ✅ Direct API (`starburst_map`, `starburst_cluster`)
 - ✅ EC2 backend (default, with spot instances) + Fargate (serverless

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,51 +1,39 @@
-## Resubmission (5th)
+## Submission
 
-This resubmission fixes the invalid file URI flagged by CRAN's pretest in v0.3.8.
+This is a minor update from the current CRAN release (0.3.8) to 0.3.9.
 
-### Changes made in this resubmission:
+### Notable changes in 0.3.9
 
-1. **Fixed invalid LICENSE URI in README.md**: Replaced relative file URI
-   `[LICENSE](LICENSE)` with full GitHub URL
-   `[LICENSE](https://github.com/scttfrdmn/starburst/blob/main/LICENSE)`.
-   CRAN's pretest flagged: "Found the following (possibly) invalid file URI:
-   URI: LICENSE From: README.md"
+* `starburst_map()` and `starburst_cluster()` now accept and forward the
+  `launch_type` / `instance_type` / `use_spot` backend arguments (previously
+  these functions had no backend selection).
+* `starburst_setup()` provisions the default EC2 capacity provider so the
+  default backend works out of the box (created at zero instances; no cost).
+* Cost estimates now use live AWS pricing (Pricing API for On-Demand, EC2
+  spot-price history for Spot), cached per session with a built-in static-rate
+  fallback when offline; the `max_hourly_cost` guard and `cost_alert_threshold`
+  are now enforced on every backend.
+* Documentation consistency pass and several corrected examples.
 
-No other changes were made. Version remains 0.3.8.
+See NEWS.md for the full list.
 
 ## Test environments
 
-* local: macOS 26.3 (Tahoe), R 4.5.2
+* local: macOS 26.5 (Tahoe), R 4.6.1
 * GitHub Actions:
   - Ubuntu 22.04, R oldrel-1, release, devel
   - Windows latest, R release
   - macOS latest, R release
-* win-builder: R-devel (r89498)
+* win-builder: R-devel
 
 ## R CMD check results
 
-0 errors ✓ | 0 warnings ✓ | 1 NOTE
+0 errors | 0 warnings | 0 notes
 
-```
-* checking CRAN incoming feasibility ... NOTE
-Maintainer: 'Scott Friedman <help@starburst.ing>'
-
-New submission
-```
-
-This NOTE is expected and unavoidable for any new CRAN submission.
+All tests requiring AWS credentials are gated (skipped on CRAN); `\donttest`
+examples guard on `starburst_is_configured()` and make no network calls when
+credentials are absent.
 
 ## Downstream dependencies
 
 There are currently no downstream dependencies for this package.
-
-## CRAN submission notes
-
-The package provides seamless 'Amazon Web Services' ('AWS') cloud bursting
-for parallel R workloads on 'EC2' and 'Fargate'.
-
-Key points for reviewers:
-- All tests requiring AWS credentials are gated with `skip_if_offline()`
-  and will not run on CRAN's test servers
-- Package includes 12 vignettes with real-world examples in `inst/doc/`
-- Default backend is 'EC2' with spot instances for cost optimization
-- Fully documented with 29+ exported functions


### PR DESCRIPTION
Cuts the 0.3.9 CRAN release, retiring the development-version banner.

## Changes
- **NEWS.md** — date the 0.3.9 section (2026-07-22); the changelog content was already finalized across prior PRs (cost-contract + live pricing, one-step EC2 setup, backend args, detached-collect fix, doc-consistency, Getting Started trim, ROADMAP removal).
- **README** — drop the "development version 0.3.9 vs CRAN 0.3.8" divergence banner (0.3.9 *is* the CRAN release now); simplify install to CRAN + GitHub-dev; roadmap marks 0.3.9 current and adds the live-pricing bullet. Regenerated README.md.
- **cran-comments.md** — rewritten for the 0.3.9 minor-update submission.

## Verification
`devtools::check()` with AWS creds unset (mirrors CRAN; `\donttest` examples make no network calls when unconfigured):

```
0 errors | 0 warnings | 0 notes
--run-donttest OK
```

Post-merge: tag `v0.3.9` and submit to CRAN via `devtools::submit_cran()`.