### PR TITLE
ci: build base images on GitHub-hosted runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@
 #
 # Updates are grouped into a single weekly PR to keep review cost low. Note that
 # merging a bump inside build-base-images.yml triggers a real public-ECR base
-# image publish on the self-hosted runners (that workflow watches its own path
-# on push to main) — review those merges deliberately.
+# image publish (that workflow watches its own path on push to main) — review
+# those merges deliberately.
 version: 2
 
 updates:

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -27,30 +27,36 @@ env:
   LATEST_R_VERSION: '4.6.1'
 
 jobs:
-  # Build each architecture NATIVELY on a self-hosted runner (no QEMU emulation):
-  #   amd64 -> janus (Linux x86_64), arm64 -> orion (macOS/colima, arm64).
+  # Build each architecture NATIVELY on a GitHub-hosted runner (no QEMU emulation):
+  #   amd64 -> ubuntu-24.04, arm64 -> ubuntu-24.04-arm.
   # Each job pushes a single-arch, per-arch tag; the `merge` job then assembles the
   # final multi-arch manifest. Native builds avoid the ~80-min emulated arm64 build.
+  # GitHub's Linux arm64 images are free on public repositories, which this is.
   #
-  # SECURITY: self-hosted runners on a public repo. Safe because this workflow has
-  # NO pull_request trigger (only schedule / workflow_dispatch / push-to-main), and
-  # the repo requires approval for all external contributors' workflow runs — so a
-  # fork PR cannot execute on these runners.
+  # SECURITY: this workflow has NO pull_request trigger (only schedule /
+  # workflow_dispatch / push-to-main), so a fork PR can never reach the OIDC role
+  # or the public-ECR push credentials.
   build:
     strategy:
       fail-fast: false
       matrix:
         r_version: ['4.5.3', '4.6.1']
         arch: [amd64, arm64]
-    # Select the native runner by arch: amd64 -> janus, arm64 -> orion.
-    # (Both carry the shared `starburst` label plus their arch label.)
-    runs-on: [self-hosted, starburst, "${{ matrix.arch }}"]
+    # Native runner per arch — no cross-building, no emulation.
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      # Registry push needs a builder whose driver supports it. The
+      # docker-container driver always does; the runner's default `docker` driver
+      # depends on how its image store is configured, so don't rely on it. Same
+      # reasoning as ensure_buildx_builder() in R/images.R.
+      - name: Create buildx builder
+        run: docker buildx create --name starburst-ci --driver docker-container --use
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -74,8 +80,8 @@ jobs:
             .
 
   # Combine the per-arch images into one multi-arch manifest per R version, plus
-  # the dated tag and :latest (for the latest R version). imagetools works on the
-  # registry, so this runs fine on a GitHub-hosted runner.
+  # the dated tag and :latest (for the latest R version). imagetools operates on the
+  # registry rather than on a local build, so it needs no builder setup.
   merge:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
The self-hosted runners (`janus` amd64, `orion` arm64) have been removed, so `build-base-images.yml`'s build job could no longer schedule. This moves it to GitHub-hosted runners.

## Change

Keeps the native per-arch design — that structure exists specifically to avoid the ~80-minute QEMU-emulated arm64 build, and GitHub's Linux arm64 images are free on public repositories, so nothing is lost:

```diff
-    runs-on: [self-hosted, starburst, "${{ matrix.arch }}"]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
```

An expression on `runs-on` keeps the 2×2 (`r_version` × `arch`) matrix and the downstream `merge` job untouched — `merge` assembles the multi-arch manifest from the per-arch tags via `imagetools`, which works registry-side and needs no builder.

Also adds an explicit `docker-container` buildx builder. Registry push needs a driver that supports it: `docker-container` always does, while the runner's default `docker` driver depends on how its image store is configured. I tested the default driver locally and it *did* push, but that was Docker Desktop with the containerd image store — not what a GitHub runner has — so this doesn't rely on it. Same reasoning as `ensure_buildx_builder()` at `R/images.R:271`.

The `SECURITY:` comment about self-hosted runners on a public repo is replaced with the part that still applies: no `pull_request` trigger, so a fork PR cannot reach the OIDC role or the public-ECR push credentials. The stale "self-hosted" mention in `dependabot.yml` is dropped too — `git grep -niE "self-hosted|orion|janus"` is now empty repo-wide.

## Verification

- Workflow parses; `build` resolves to the expression above, `merge`/`create-release` stay on `ubuntu-latest`.
- ⚠️ **Not yet executed.** This workflow only runs on schedule / `workflow_dispatch` / push-to-main touching its own path — and it publishes real images to public ECR. Merging it will itself trigger a publish (it watches its own path), which is the honest end-to-end test; happy to `workflow_dispatch` it first instead if you'd rather verify before merge.
- Note: `GET /repos/scttfrdmn/starburst/actions/runners` still lists `janus-starburst` and `orion-starburst` as **online**, so they may want deregistering at the repo level.