### PR TITLE
fix: base images ship without qs2 — add cmake + fail on silent install failure

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -69,15 +69,33 @@ jobs:
           aws ecr-public get-login-password --region us-east-1 | \
             docker login --username AWS --password-stdin public.ecr.aws
 
-      - name: Build and push single-arch base image (native)
+      # Build into the local image store, smoke-test, and only then push, so a
+      # broken image cannot reach the registry at all.
+      - name: Build single-arch base image (native)
         run: |
           docker buildx build \
             --file inst/templates/Dockerfile.base \
             --build-arg R_VERSION=${{ matrix.r_version }} \
             --platform linux/${{ matrix.arch }} \
             --tag ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.REPOSITORY_NAME }}:r${{ matrix.r_version }}-${{ matrix.arch }} \
-            --push \
+            --load \
             .
+
+      # Assert the worker packages are actually usable in the image users pull.
+      # Dockerfile.base now fails on a missing package itself, but check here too:
+      # requireNamespace() also catches packages that are installed yet fail to
+      # LOAD (e.g. a shared object linked against the wrong library), which
+      # install-time checks cannot see. See #55.
+      - name: Smoke-test the image
+        run: |
+          docker run --rm \
+            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.REPOSITORY_NAME }}:r${{ matrix.r_version }}-${{ matrix.arch }} \
+            Rscript -e 'pkgs <- c("renv", "future", "globals", "listenv", "parallelly", "qs2", "paws.common", "paws.storage", "paws.compute"); bad <- pkgs[!vapply(pkgs, requireNamespace, logical(1), quietly = TRUE)]; if (length(bad)) stop("unusable in image: ", paste(bad, collapse = ", ")); cat("all worker packages load |", R.version.string, "|", R.version$platform, "\n")'
+
+      - name: Push single-arch base image
+        run: |
+          docker push \
+            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.REPOSITORY_NAME }}:r${{ matrix.r_version }}-${{ matrix.arch }}
 
   # Combine the per-arch images into one multi-arch manifest per R version, plus
   # the dated tag and :latest (for the latest R version). imagetools operates on the

--- a/inst/templates/Dockerfile.base
+++ b/inst/templates/Dockerfile.base
@@ -8,7 +8,10 @@ ARG R_VERSION=4.6.1
 FROM rocker/r-ver:${R_VERSION}
 
 # Install system dependencies
+# cmake is required to build RcppParallel >= 6.2.0, which qs2 needs via
+# stringfish. Without it qs2 silently fails to install (see #55).
 RUN apt-get update && apt-get install -y \
+    cmake \
     libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
@@ -27,11 +30,17 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install renv first (needed for all projects)
-RUN R -e "install.packages('renv', repos = 'https://cloud.r-project.org')"
+RUN R -e "install.packages('renv', repos = 'https://cloud.r-project.org'); \
+    if (!requireNamespace('renv', quietly = TRUE)) stop('renv failed to install')"
 
 # Install commonly used staRburst dependencies
-# These are required for worker functionality and rarely change
-RUN R -e "install.packages(c(\
+# These are required for worker functionality and rarely change.
+#
+# install.packages() only WARNS when a package fails to build, so the missing
+# packages must be checked explicitly — otherwise this layer exits 0 and a broken
+# image is published with a green build. That is exactly how qs2 went missing from
+# every published tag for 12 days (#55).
+RUN R -e "pkgs <- c(\
     'future', \
     'globals', \
     'listenv', \
@@ -40,7 +49,10 @@ RUN R -e "install.packages(c(\
     'paws.common', \
     'paws.storage', \
     'paws.compute' \
-    ), repos = 'https://cloud.r-project.org')"
+    ); \
+    install.packages(pkgs, repos = 'https://cloud.r-project.org'); \
+    bad <- pkgs[!vapply(pkgs, requireNamespace, logical(1), quietly = TRUE)]; \
+    if (length(bad)) stop('failed to install: ', paste(bad, collapse = ', '))"
 
 # Set working directory for subsequent builds
 WORKDIR /app


### PR DESCRIPTION
Fixes #55. Found while verifying the hosted-runner migration (#54) by actually pulling and running the published image, rather than trusting the green build.

## The bug

Every published tag — `latest`, `r4.6.1`, `r4.5.3`, on **both** arches — is missing `qs2`, the serialization format used for every task and result. arm64 is the *default* worker architecture (`c7g.xlarge` is Graviton), so the default path is the broken one.

`RcppParallel 6.2.0` (2026-07-30) requires cmake at configure time; `Dockerfile.base` does not install it:

```
error: RcppParallel requires cmake (>= 3.5); cmake was not found
ERROR: dependency ‘RcppParallel’ is not available for package ‘stringfish’
ERROR: dependencies ‘RcppParallel’, ‘stringfish’ are not available for package ‘qs2’
```

The worse half is that it was **silent**. `install.packages()` only warns, so the layer exited 0, CI went green, and broken images published twice: [2026-08-01](https://github.com/scttfrdmn/starburst/actions/runs/30675111356) on the old self-hosted runners, and [2026-08-13](https://github.com/scttfrdmn/starburst/actions/runs/31748081644) after the migration. Not caused by the migration — the Aug 1 failure predates it. `bench/worker-renv.lock`, generated from the image on 2026-07-21, still records `qs2 0.2.2` / `RcppParallel 5.1.11-2`, which pins the regression to the RcppParallel release.

## Fix, in three layers

1. **`Dockerfile.base` installs cmake** — addresses the immediate cause.
2. **Both install layers verify and `stop()`** on anything missing, so a failed dependency fails the build instead of warning. This is the layer that matters: without it the same class of breakage recurs on the next dependency change.
3. **The workflow builds with `--load`, smoke-tests, then pushes** — so a broken image cannot reach the registry at all. The smoke test uses `requireNamespace()`, which also catches installed-but-*unloadable* packages (e.g. a shared object linked against the wrong library — precisely what hit macOS CI earlier today) that an install-time check cannot see.

## Verification

Built and run locally on native arm64:

```
ALL LOAD | R version 4.6.1 (2026-06-24) | aarch64-unknown-linux-gnu
qs2 0.2.2 / RcppParallel 6.2.0 / stringfish 0.19.2
$a
[1] 1
$b
[1] "x"          # qs2 save/read round-trip through the image
```

The guard was checked separately to exit non-zero on a missing package (`exit code = 1`).

⚠️ Merging republishes the base images — this workflow watches its own path on push to `main`. That is the intended outcome here, since the currently published tags are broken.